### PR TITLE
Update CLI to use promotions endpoint

### DIFF
--- a/commands/pipelines/promote.js
+++ b/commands/pipelines/promote.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const cli = require('heroku-cli-util');
-const Promise = require('bluebird');
+const BBPromise = require('bluebird');
 
 const PROMOTION_ORDER = ["development", "staging", "production"];
 const V3_HEADER = 'application/vnd.heroku+json; version=3';
@@ -27,7 +27,7 @@ function pollPromotionStatus(heroku, id) {
   }).then(function(targets) {
     if (targets.every(isComplete)) { return targets; }
 
-    return Promise.delay(1000).then(pollPromotionStatus.bind(null, heroku, id));
+    return BBPromise.delay(1000).then(pollPromotionStatus.bind(null, heroku, id));
   });
 }
 

--- a/test/commands/pipelines/promote.js
+++ b/test/commands/pipelines/promote.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const cli  = require('heroku-cli-util');
+const nock = require('nock');
+const cmd  = require('../../../commands/pipelines/promote');
+
+describe('pipelines:promote', function() {
+  const pipeline = {
+    id: '123-pipeline-456',
+    name: 'example-pipeline'
+  };
+
+  const sourceApp = {
+    id: '123-source-app-456',
+    name: 'example-staging',
+    coupling: { stage: 'staging' },
+    pipeline: pipeline
+  };
+
+  const targetApp1 = {
+    id: '123-target-app-456',
+    name: 'example-production',
+    coupling: { stage: 'production' },
+    pipeline: pipeline
+  };
+
+  const targetApp2 = {
+    id: '456-target-app-789',
+    name: 'example-production-eu',
+    coupling: { stage: 'production' },
+    pipeline: pipeline
+  };
+
+  const sourceCoupling = {
+    app: sourceApp,
+    id: '123-source-app-456',
+    pipeline: pipeline,
+    stage: 'staging'
+  };
+
+  const promotion = {
+    id: '123-promotion-456',
+    source: { app: sourceApp },
+    status: 'pending'
+  };
+
+  beforeEach(function () {
+    cli.mockConsole();
+  });
+
+  it('promotes to all apps in the next stage', function() {
+    nock('https://api.heroku.com')
+      .get(`/apps/${sourceApp.name}/pipeline-couplings`)
+      .reply(200, sourceCoupling);
+
+    nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}/apps`)
+      .reply(200, [sourceApp, targetApp1, targetApp2]);
+
+    const req = nock('https://api.heroku.com').post('/pipeline-promotions', {
+      pipeline: { id: pipeline.id },
+      source:   { app: { id: sourceApp.id } },
+      targets:  [
+        { app: { id: targetApp1.id } },
+        { app: { id: targetApp2.id } }
+      ]
+    }).reply(201, promotion);
+
+    return cmd.run({ app: sourceApp.name }).then(req.done);
+  });
+});

--- a/test/commands/pipelines/promote.js
+++ b/test/commands/pipelines/promote.js
@@ -84,13 +84,14 @@ describe('pipelines:promote', function() {
           app: { id: targetApp2.id },
           // Return failed on the second poll loop
           status: pollCount > 1 ? 'failed' : 'pending',
-          error_message: pollCount > 1 ? 'Failed because reasons' : null
+          error_message: pollCount > 1 ? 'Because reasons' : null
         }];
       });
 
     return cmd.run({ app: sourceApp.name }).then(function() {
       req.done();
-      expect(cli.stdout).to.contain('Example-Production-Eu: Failed because reasons');
+      expect(cli.stdout).to.contain('failed');
+      expect(cli.stdout).to.contain('Because reasons');
     });
   });
 });


### PR DESCRIPTION
- [x] Use `POST /pipeline-promotions` from CLI
- [x] Poll `GET /pipeline-promotions/:id/promotion-targets` to show status

This still requires more requests than I'd like, it'd be great to allow the `targets` hash to be excluded entirely in the API.

```bash
❯ heroku pipelines:promote -a edamame-dev
Fetching app info... done
Fetching apps from edamame... done
Starting promotion to staging... done
Waiting for promotion to complete... done

Promotion successful
Edamame-Staging:    succeeded
Edamame-Staging-Eu: succeeded
```