### PR TITLE
Remove redundant stages

### DIFF
--- a/commands/pipelines/add.js
+++ b/commands/pipelines/add.js
@@ -4,6 +4,7 @@ let cli = require('heroku-cli-util');
 let infer = require('../../lib/infer');
 let disambiguate = require('../../lib/disambiguate');
 let prompt = require('../../lib/prompt');
+let stageNames = require('../../lib/stages').names;
 
 module.exports = {
   topic: 'pipelines',
@@ -32,7 +33,7 @@ module.exports = {
         type: "list",
         name: "stage",
         message: `Stage of ${context.app}`,
-        choices: ["review", "development", "test", "qa", "staging", "production"],
+        choices: stageNames,
         default: guesses[1]
       });
     }

--- a/commands/pipelines/create.js
+++ b/commands/pipelines/create.js
@@ -4,6 +4,7 @@ let cli = require('heroku-cli-util');
 let co  = require('co');
 let infer = require('../../lib/infer');
 let prompt = require('../../lib/prompt');
+let stages = require('../../lib/stages').names;
 
 function* run(context, heroku) {
   var name, stage;
@@ -27,7 +28,7 @@ function* run(context, heroku) {
       type: "list",
       name: "stage",
       message: `Stage of ${context.app}`,
-      choices: ["review", "development", "test", "qa", "staging", "production"],
+      choices: stages,
       default: guesses[1]
     });
   }

--- a/commands/pipelines/info.js
+++ b/commands/pipelines/info.js
@@ -2,6 +2,7 @@
 
 let cli          = require('heroku-cli-util');
 let disambiguate = require('../../lib/disambiguate');
+let stageNames   = require('../../lib/stages').names;
 
 module.exports = {
   topic: 'pipelines',
@@ -23,7 +24,7 @@ module.exports = {
     // Sort Apps by stage, name
     // Display in table
     let stages={};
-    for (var app in apps) {
+    for (let app in apps) {
       if (apps.hasOwnProperty(app)) {
         let stage = apps[app].coupling.stage;
         if(stages[stage]) {
@@ -34,6 +35,6 @@ module.exports = {
       }
     }
     // Pass in sort order for stages
-    cli.styledHash(stages, ["review", "development", "test", "qa", "staging", "production"]);
+    cli.styledHash(stages, stageNames);
   })
 };

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -1,32 +1,13 @@
 'use strict';
 
-const stageMap = [
-  {
-    stage: 'development',
-    regex: /-(dev|development)$/
-  },{
-    stage: 'test',
-    regex: /-(uat|tst|test)$/
-  },{
-    stage: 'qa',
-    regex: /-qa$/
-  },{
-    stage: 'staging',
-    regex: /-(stg|staging)$/
-  },{
-    stage: 'production',
-    regex: /-(prd|prod|production|admin|demo)$/
-  },{
-    stage: 'review',
-    regex: /-pr-(\d+)$/
-  }
-];
+const stages = require('./stages').stages;
 
 module.exports = function infer(app) {
-  for (var val of stageMap) {
-    if(val.regex.test(app)) {
-      return [app.replace(val.regex,""), val.stage];
-    }
+  const inferredStage = stages.find(stage => stage.inferRegex.test(app));
+
+  if (inferredStage) {
+    return [ app.replace(inferredStage.inferRegex, ''), inferredStage.name ];
   }
-  return [app,"production"];
+
+  return [ app, 'production' ];
 };

--- a/lib/stages.js
+++ b/lib/stages.js
@@ -1,0 +1,29 @@
+const STAGES = [
+  {
+    name: 'review',
+    inferRegex:  /-pr-(\d+)$/
+  },
+  {
+    name: 'development',
+    inferRegex: /-(dev|development)$/
+  },
+  {
+    name: 'test',
+    inferRegex: /-(uat|tst|test)$/
+  },
+  {
+    name: 'qa',
+    inferRegex: /-qa$/
+  },
+  {
+    name: 'staging',
+    inferRegex: /-(stg|staging)$/
+  },
+  {
+    name: 'production',
+    inferRegex: /-(prd|prod|production|admin|demo)$/
+  }
+];
+
+exports.stages = STAGES;
+exports.names  = STAGES.map((stage) => stage.name);

--- a/lib/stages.js
+++ b/lib/stages.js
@@ -8,14 +8,6 @@ const STAGES = [
     inferRegex: /-(dev|development)$/
   },
   {
-    name: 'test',
-    inferRegex: /-(uat|tst|test)$/
-  },
-  {
-    name: 'qa',
-    inferRegex: /-qa$/
-  },
-  {
     name: 'staging',
     inferRegex: /-(stg|staging)$/
   },

--- a/test/lib/infer.js
+++ b/test/lib/infer.js
@@ -6,20 +6,15 @@ const tests = {
   development: ['www-dev', 'www-development', 'acme-www-development', 'www2-development'],
   staging: ['www-staging', 'www-stg'],
   review: ['www-pr-123', 'www-staging-pr-123'],
-  test: ['www-test', 'www-tst', 'www-uat'],
-  qa: ['www-qa'],
   production: ['www-prod', 'www-production', 'www-admin', 'www-demo', 'www-prd', 'www', 'www-none', 'www-staging2', 'www-pr-preview']
 };
 
 describe('infer', function () {
-  it('categorizes correctly', function () {
-    for(var stage in tests) {
-      if(tests.hasOwnProperty(stage)) {
-        for(var example of tests[stage]) {
-          infer(example)[1].should.equal(stage);
-        }
+  Object.keys(tests).forEach(function(stage) {
+    it(`categorizes the ${stage} stage correctly`, function() {
+      for(let example of tests[stage]) {
+        infer(example)[1].should.equal(stage);
       }
-    }
-    return;
+    });
   });
 });


### PR DESCRIPTION
- Factor out stage information to a single file.
- Stop suggesting `qa` and `test` stages.