### PR TITLE
Use new pipeline-couplings endpoints

### DIFF
--- a/commands/pipelines/add.js
+++ b/commands/pipelines/add.js
@@ -6,6 +6,8 @@ let disambiguate = require('../../lib/disambiguate');
 let prompt = require('../../lib/prompt');
 let stageNames = require('../../lib/stages').names;
 
+const createCoupling = require('../../lib/api').createCoupling;
+
 module.exports = {
   topic: 'pipelines',
   command: 'add',
@@ -41,12 +43,8 @@ module.exports = {
     }
     let answers = yield prompt(questions);
     if (answers.stage) stage = answers.stage;
-    let promise = heroku.request({
-      method: 'POST',
-      path: `/apps/${context.app}/pipeline-couplings`,
-      body: {pipeline: {id: pipeline.id}, stage: stage},
-      headers: { 'Accept': 'application/vnd.heroku+json; version=3.pipelines' }
-    }); // heroku.apps(app_id).pipline_couplings().create(body);
-    yield cli.action(`Adding ${context.app} to ${pipeline.name} pipeline as ${stage}`, promise);
+
+    yield cli.action(`Adding ${app} to ${pipeline.name} pipeline as ${stage}`,
+                    createCoupling(heroku, pipeline, app, stage));
   })
 };

--- a/commands/pipelines/add.js
+++ b/commands/pipelines/add.js
@@ -20,6 +20,8 @@ module.exports = {
     {name: 'stage', char: 's', description: 'stage of first app in pipeline', hasValue: true}
   ],
   run: cli.command(function* (context, heroku) {
+    const app = context.app;
+
     var stage;
     let guesses = infer(context.app);
     let questions = [];
@@ -32,7 +34,7 @@ module.exports = {
       questions.push({
         type: "list",
         name: "stage",
-        message: `Stage of ${context.app}`,
+        message: `Stage of ${app}`,
         choices: stageNames,
         default: guesses[1]
       });

--- a/commands/pipelines/create.js
+++ b/commands/pipelines/create.js
@@ -6,6 +6,8 @@ let infer = require('../../lib/infer');
 let prompt = require('../../lib/prompt');
 let stages = require('../../lib/stages').names;
 
+const createCoupling = require('../../lib/api').createCoupling;
+
 function* run(context, heroku) {
   var name, stage;
   let guesses = infer(context.app);
@@ -44,13 +46,9 @@ function* run(context, heroku) {
     headers: { 'Accept': 'application/vnd.heroku+json; version=3.pipelines' }
   }); // heroku.pipelines().create({name: name});
   let pipeline = yield cli.action(`Creating ${name} pipeline`, promise);
-  promise = heroku.request({
-    method: 'POST',
-    path: `/apps/${app}/pipeline-couplings`,
-    body: {pipeline: {id: pipeline.id}, stage: stage},
-    headers: { 'Accept': 'application/vnd.heroku+json; version=3.pipelines' }
-  }); // heroku.apps(app_id).pipline_couplings().create(body);
-  yield cli.action(`Adding ${app} to ${pipeline.name} pipeline as ${stage}`, promise);
+
+  yield cli.action(`Adding ${app} to ${pipeline.name} pipeline as ${stage}`,
+                  createCoupling(heroku, pipeline, app, stage));
 }
 
 module.exports = {

--- a/commands/pipelines/create.js
+++ b/commands/pipelines/create.js
@@ -11,6 +11,8 @@ function* run(context, heroku) {
   let guesses = infer(context.app);
   let questions = [];
 
+  const app = context.app;
+
   if (context.args.name) {
     name = context.args.name;
   } else {
@@ -27,7 +29,7 @@ function* run(context, heroku) {
     questions.push({
       type: "list",
       name: "stage",
-      message: `Stage of ${context.app}`,
+      message: `Stage of ${app}`,
       choices: stages,
       default: guesses[1]
     });
@@ -44,11 +46,11 @@ function* run(context, heroku) {
   let pipeline = yield cli.action(`Creating ${name} pipeline`, promise);
   promise = heroku.request({
     method: 'POST',
-    path: `/apps/${context.app}/pipeline-couplings`,
+    path: `/apps/${app}/pipeline-couplings`,
     body: {pipeline: {id: pipeline.id}, stage: stage},
     headers: { 'Accept': 'application/vnd.heroku+json; version=3.pipelines' }
   }); // heroku.apps(app_id).pipline_couplings().create(body);
-  yield cli.action(`Adding ${context.app} to ${pipeline.name} pipeline as ${stage}`, promise);
+  yield cli.action(`Adding ${app} to ${pipeline.name} pipeline as ${stage}`, promise);
 }
 
 module.exports = {

--- a/commands/pipelines/diff.js
+++ b/commands/pipelines/diff.js
@@ -109,6 +109,7 @@ function* diff(targetApp, downstreamApp, githubToken, herokuUserAgent) {
 }
 
 function* run(context, heroku) {
+  // jshint maxstatements:65
   const targetAppName = context.app;
   let coupling;
   try {
@@ -168,7 +169,7 @@ function* run(context, heroku) {
     yield diff(
       targetAppInfo, downstreamAppInfo, githubAccount.github.token, heroku.options.userAgent);
   }
-};
+}
 
 module.exports = {
   topic: 'pipelines',

--- a/commands/pipelines/diff.js
+++ b/commands/pipelines/diff.js
@@ -108,71 +108,73 @@ function* diff(targetApp, downstreamApp, githubToken, herokuUserAgent) {
   }
 }
 
+function* run(context, heroku) {
+  const targetAppName = context.app;
+  let coupling;
+  try {
+    coupling = yield heroku.request({
+      method: 'GET',
+      path: `/apps/${targetAppName}/pipeline-couplings`,
+      headers: { 'Accept': PIPELINES_HEADER }
+    });
+  } catch (err) {
+    return cli.error(`This app (${targetAppName}) does not seem to be a part of any pipeline`);
+  }
+  const targetAppId = coupling.app.id;
+
+  const allApps = yield cli.action(`Fetching apps from pipeline`,
+    heroku.request({
+      method: 'GET',
+      path: `/pipelines/${coupling.pipeline.id}/apps`,
+      headers: { 'Accept': PIPELINES_HEADER }
+    }));
+
+  const sourceStage = coupling.stage;
+  const downstreamStage = PROMOTION_ORDER[PROMOTION_ORDER.indexOf(sourceStage) + 1];
+  if (downstreamStage === null || PROMOTION_ORDER.indexOf(sourceStage) < 0) {
+    return cli.error(`Unable to diff ${targetAppName}`);
+  }
+  const downstreamApps = allApps.filter(function(app) {
+    return app.coupling.stage === downstreamStage;
+  });
+
+  if (downstreamApps.length < 1) {
+    return cli.error(`Cannot diff ${targetAppName} as there are no downstream apps configured`);
+  }
+
+  // Fetch GitHub repo/latest release hash for [target, downstream[0], .., downstream[n]] apps
+  const wrappedGetAppInfo = co.wrap(getAppInfo);
+  const appInfoPromises = [wrappedGetAppInfo(heroku, targetAppName, targetAppId)];
+  downstreamApps.forEach(function (app) {
+    appInfoPromises.push(wrappedGetAppInfo(heroku, app.name, app.id));
+  });
+  const appInfo = yield cli.action(`Fetching release info for all apps`,
+    bluebird.all(appInfoPromises));
+
+  // Verify the target app
+  let targetAppInfo = appInfo[0];
+  if (targetAppInfo.repo === null) {
+    return cli.error(`${targetAppName} does not seem to be connected to GitHub!`);
+  } else if (targetAppInfo.hash === null) {
+    return cli.error(`No release was found for ${targetAppName}, unable to diff`);
+  }
+
+  // Fetch GitHub token for the user
+  const githubAccount = yield kolkrabbiRequest(`/account/github/token`, heroku.options.token);
+
+  // Diff [{target, downstream[0]}, {target, downstream[1]}, .., {target, downstream[n]}]
+  const downstreamAppsInfo = appInfo.slice(1);
+  for (let downstreamAppInfo of downstreamAppsInfo) {
+    yield diff(
+      targetAppInfo, downstreamAppInfo, githubAccount.github.token, heroku.options.userAgent);
+  }
+};
+
 module.exports = {
   topic: 'pipelines',
   command: 'diff',
   description: 'compares the latest release of this app its downstream app(s)',
   needsAuth: true,
   needsApp: true,
-  run: cli.command(function* (context, heroku) {
-    const targetAppName = context.app;
-    let coupling;
-    try {
-      coupling = yield heroku.request({
-        method: 'GET',
-        path: `/apps/${targetAppName}/pipeline-couplings`,
-        headers: { 'Accept': PIPELINES_HEADER }
-      });
-    } catch (err) {
-      return cli.error(`This app (${targetAppName}) does not seem to be a part of any pipeline`);
-    }
-    const targetAppId = coupling.app.id;
-
-    const allApps = yield cli.action(`Fetching apps from pipeline`,
-      heroku.request({
-        method: 'GET',
-        path: `/pipelines/${coupling.pipeline.id}/apps`,
-        headers: { 'Accept': PIPELINES_HEADER }
-      }));
-
-    const sourceStage = coupling.stage;
-    const downstreamStage = PROMOTION_ORDER[PROMOTION_ORDER.indexOf(sourceStage) + 1];
-    if (downstreamStage === null || PROMOTION_ORDER.indexOf(sourceStage) < 0) {
-      return cli.error(`Unable to diff ${targetAppName}`);
-    }
-    const downstreamApps = allApps.filter(function(app) {
-      return app.coupling.stage === downstreamStage;
-    });
-
-    if (downstreamApps.length < 1) {
-      return cli.error(`Cannot diff ${targetAppName} as there are no downstream apps configured`);
-    }
-
-    // Fetch GitHub repo/latest release hash for [target, downstream[0], .., downstream[n]] apps
-    const wrappedGetAppInfo = co.wrap(getAppInfo);
-    const appInfoPromises = [wrappedGetAppInfo(heroku, targetAppName, targetAppId)];
-    downstreamApps.forEach(function (app) {
-      appInfoPromises.push(wrappedGetAppInfo(heroku, app.name, app.id));
-    });
-    const appInfo = yield cli.action(`Fetching release info for all apps`,
-      bluebird.all(appInfoPromises));
-
-    // Verify the target app
-    let targetAppInfo = appInfo[0];
-    if (targetAppInfo.repo === null) {
-      return cli.error(`${targetAppName} does not seem to be connected to GitHub!`);
-    } else if (targetAppInfo.hash === null) {
-      return cli.error(`No release was found for ${targetAppName}, unable to diff`);
-    }
-
-    // Fetch GitHub token for the user
-    const githubAccount = yield kolkrabbiRequest(`/account/github/token`, heroku.options.token);
-
-    // Diff [{target, downstream[0]}, {target, downstream[1]}, .., {target, downstream[n]}]
-    const downstreamAppsInfo = appInfo.slice(1);
-    for (let downstreamAppInfo of downstreamAppsInfo) {
-      yield diff(
-        targetAppInfo, downstreamAppInfo, githubAccount.github.token, heroku.options.userAgent);
-    }
-  })
+  run: cli.command(co.wrap(run))
 };

--- a/commands/pipelines/remove.js
+++ b/commands/pipelines/remove.js
@@ -2,6 +2,8 @@
 
 let cli = require('heroku-cli-util');
 
+const removeCoupling = require('../../lib/api').removeCoupling;
+
 module.exports = {
   topic: 'pipelines',
   command: 'remove',
@@ -10,12 +12,8 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   run: cli.command(function* (context, heroku) {
-    let promise = heroku.request({
-      method: 'DELETE',
-      path: `/apps/${context.app}/pipeline-couplings`,
-      headers: { 'Accept': 'application/vnd.heroku+json; version=3.pipelines' }
-    }); // heroku.apps(app).pipeline-couplings().destroy();
-    let pipeline = yield cli.action(`Removing ${context.app}`, promise);
-    cli.hush(pipeline);
+    const app = context.app;
+
+    yield cli.action(`Removing ${app}`, removeCoupling(heroku, app));
   })
 };

--- a/commands/pipelines/update.js
+++ b/commands/pipelines/update.js
@@ -13,10 +13,10 @@ function getCoupling(heroku, app) {
   });
 }
 
-function patchCoupling(heroku, coupling, stage) {
+function patchCoupling(heroku, id, stage) {
   return heroku.request({
     method: 'PATCH',
-    path: `/pipeline-couplings/${coupling.id}`,
+    path: `/pipeline-couplings/${id}`,
     body: {stage: stage},
     headers: { 'Accept': PIPELINES_HEADER }
   });
@@ -24,7 +24,7 @@ function patchCoupling(heroku, coupling, stage) {
 
 function updateCoupling(heroku, app, stage) {
   return getCoupling(heroku, app)
-           .then(coupling => patchCoupling(heroku, coupling, stage));
+           .then(coupling => patchCoupling(heroku, coupling.id, stage));
 }
 
 module.exports = {

--- a/commands/pipelines/update.js
+++ b/commands/pipelines/update.js
@@ -1,31 +1,7 @@
 'use strict';
 
 let cli = require('heroku-cli-util');
-
-const V3_HEADER = 'application/vnd.heroku+json; version=3';
-const PIPELINES_HEADER = V3_HEADER + '.pipelines';
-
-function getCoupling(heroku, app) {
-  return heroku.request({
-    method: 'GET',
-    path: `/apps/${app}/pipeline-couplings`,
-    headers: { 'Accept': PIPELINES_HEADER }
-  });
-}
-
-function patchCoupling(heroku, id, stage) {
-  return heroku.request({
-    method: 'PATCH',
-    path: `/pipeline-couplings/${id}`,
-    body: {stage: stage},
-    headers: { 'Accept': PIPELINES_HEADER }
-  });
-}
-
-function updateCoupling(heroku, app, stage) {
-  return getCoupling(heroku, app)
-           .then(coupling => patchCoupling(heroku, coupling.id, stage));
-}
+const updateCoupling = require('../../lib/api').updateCoupling;
 
 module.exports = {
   topic: 'pipelines',

--- a/lib/api.js
+++ b/lib/api.js
@@ -9,6 +9,15 @@ function getCoupling(heroku, app) {
   });
 }
 
+function postCoupling(heroku, pipeline, app, stage) {
+    return heroku.request({
+      method: 'POST',
+      path: '/pipeline-couplings',
+      body: {app: app, pipeline: pipeline, stage: stage},
+      headers: { 'Accept': PIPELINES_HEADER }
+    });
+}
+
 function patchCoupling(heroku, id, stage) {
   return heroku.request({
     method: 'PATCH',
@@ -26,6 +35,10 @@ function deleteCoupling(heroku, id) {
   });
 }
 
+function createCoupling(heroku, pipeline, app, stage) {
+  return postCoupling(heroku, pipeline.id, app, stage);
+}
+
 function updateCoupling(heroku, app, stage) {
   return getCoupling(heroku, app)
            .then(coupling => patchCoupling(heroku, coupling.id, stage));
@@ -37,8 +50,10 @@ function removeCoupling(heroku, app) {
 }
 
 exports.getCoupling    = getCoupling;
+exports.postCoupling   = postCoupling;
 exports.patchCoupling  = patchCoupling;
 exports.deleteCoupling = deleteCoupling;
 
+exports.createCoupling = createCoupling;
 exports.updateCoupling = updateCoupling;
 exports.removeCoupling = removeCoupling;

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,29 @@
+const V3_HEADER = 'application/vnd.heroku+json; version=3';
+const PIPELINES_HEADER = V3_HEADER + '.pipelines';
+
+function getCoupling(heroku, app) {
+  return heroku.request({
+    method: 'GET',
+    path: `/apps/${app}/pipeline-couplings`,
+    headers: { 'Accept': PIPELINES_HEADER }
+  });
+}
+
+function patchCoupling(heroku, id, stage) {
+  return heroku.request({
+    method: 'PATCH',
+    path: `/pipeline-couplings/${id}`,
+    body: {stage: stage},
+    headers: { 'Accept': PIPELINES_HEADER }
+  });
+}
+
+function updateCoupling(heroku, app, stage) {
+  return getCoupling(heroku, app)
+           .then(coupling => patchCoupling(heroku, coupling.id, stage));
+}
+
+exports.getCoupling    = getCoupling;
+exports.patchCoupling  = patchCoupling;
+
+exports.updateCoupling = updateCoupling;

--- a/lib/api.js
+++ b/lib/api.js
@@ -18,12 +18,27 @@ function patchCoupling(heroku, id, stage) {
   });
 }
 
+function deleteCoupling(heroku, id) {
+  return heroku.request({
+    method: 'DELETE',
+    path: `/pipeline-couplings/${id}`,
+    headers: { 'Accept': PIPELINES_HEADER }
+  });
+}
+
 function updateCoupling(heroku, app, stage) {
   return getCoupling(heroku, app)
            .then(coupling => patchCoupling(heroku, coupling.id, stage));
 }
 
+function removeCoupling(heroku, app) {
+  return getCoupling(heroku, app)
+           .then(coupling => deleteCoupling(heroku, coupling.id));
+}
+
 exports.getCoupling    = getCoupling;
 exports.patchCoupling  = patchCoupling;
+exports.deleteCoupling = deleteCoupling;
 
 exports.updateCoupling = updateCoupling;
+exports.removeCoupling = removeCoupling;

--- a/test/commands/pipelines/add.js
+++ b/test/commands/pipelines/add.js
@@ -20,7 +20,7 @@ describe('pipelines:add', function () {
       .reply(200, pipelines);
 
     nock('https://api.heroku.com')
-      .post('/apps/example/pipeline-couplings')
+      .post('/pipeline-couplings')
       .reply(201, pipeline_coupling);
 
     return cmd.run({app: 'example', args: {pipeline: 'example'}, flags: {stage: 'production'}})

--- a/test/commands/pipelines/create.js
+++ b/test/commands/pipelines/create.js
@@ -16,7 +16,7 @@ describe('pipelines:create', function () {
     let heroku = nock('https://api.heroku.com')
       .post('/pipelines')
       .reply(201, pipeline)
-      .post('/apps/example/pipeline-couplings')
+      .post('/pipeline-couplings')
       .reply(201, pipeline_coupling);
 
     return cmd.run({app: 'example', args: {name: 'example'}, flags: {stage: 'production'}})

--- a/test/commands/pipelines/remove.js
+++ b/test/commands/pipelines/remove.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const cli  = require('heroku-cli-util');
+const nock = require('nock');
+const cmd  = require('../../../commands/pipelines/remove');
+
+describe('pipelines:remove', () => {
+  beforeEach(() => cli.mockConsole());
+
+  it('displays the right messages', () => {
+    const app = 'example';
+    const id  = '0123';
+
+    const pipeline_coupling = { id, stage: 'production' };
+
+    nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, pipeline_coupling);
+
+    nock('https://api.heroku.com')
+      .delete(`/pipeline-couplings/${id}`)
+      .reply(200, pipeline_coupling);
+
+    return cmd.run({ app })
+      .then(() => cli.stderr.should.contain(`Removing ${app}... done`));
+  });
+});

--- a/test/commands/pipelines/update.js
+++ b/test/commands/pipelines/update.js
@@ -5,9 +5,7 @@ const nock = require('nock');
 const cmd  = require('../../../commands/pipelines/update');
 
 describe('pipelines:update', () => {
-  beforeEach(() => {
-    cli.mockConsole();
-  });
+  beforeEach(() => cli.mockConsole());
 
   it('displays the right messages', () => {
     const app   = 'example';

--- a/test/commands/pipelines/update.js
+++ b/test/commands/pipelines/update.js
@@ -1,15 +1,15 @@
 'use strict';
 
-let cli   = require('heroku-cli-util');
-let nock  = require('nock');
-let cmd   = require('../../../commands/pipelines/update');
+const cli  = require('heroku-cli-util');
+const nock = require('nock');
+const cmd  = require('../../../commands/pipelines/update');
 
-describe('pipelines:update', function () {
-  beforeEach(function () {
+describe('pipelines:update', () => {
+  beforeEach(() => {
     cli.mockConsole();
   });
 
-  it('displays the right messages', function () {
+  it('displays the right messages', () => {
     const app   = 'example';
     const id    = '0123';
     const stage = 'production';
@@ -24,9 +24,7 @@ describe('pipelines:update', function () {
       .patch(`/pipeline-couplings/${id}`)
       .reply(200, pipeline_coupling);
 
-    return cmd.run({app: app, flags: { stage }})
-    .then(function () {
-      cli.stderr.should.contain(`Changing ${app} to ${stage}... done`);
-    });
+    return cmd.run({ app, flags: { stage } })
+      .then(() => cli.stderr.should.contain(`Changing ${app} to ${stage}... done`));
   });
 });

--- a/test/commands/pipelines/update.js
+++ b/test/commands/pipelines/update.js
@@ -1,0 +1,32 @@
+'use strict';
+
+let cli   = require('heroku-cli-util');
+let nock  = require('nock');
+let cmd   = require('../../../commands/pipelines/update');
+
+describe('pipelines:update', function () {
+  beforeEach(function () {
+    cli.mockConsole();
+  });
+
+  it('displays the right messages', function () {
+    const app   = 'example';
+    const id    = '0123';
+    const stage = 'production';
+
+    const pipeline_coupling = { id, stage };
+
+    nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, pipeline_coupling);
+
+    nock('https://api.heroku.com')
+      .patch(`/pipeline-couplings/${id}`)
+      .reply(200, pipeline_coupling);
+
+    return cmd.run({app: app, flags: { stage }})
+    .then(function () {
+      cli.stderr.should.contain(`Changing ${app} to ${stage}... done`);
+    });
+  });
+});


### PR DESCRIPTION
Changes all usages of `POST/PATCH/DELETE /apps/:id/pipeline-couplings` to use

* `POST /pipeline-couplings`
* `PATCH /pipeline-couplings/:id`
* `DELETE /pipeline-couplings/:id`

To resolve `pipeline-coupling:id` an API call is made to `GET /apps/:id/pipeline-couplings`.