### PR TITLE
Disable selection of review stage

### DIFF
--- a/lib/stages.js
+++ b/lib/stages.js
@@ -1,9 +1,5 @@
 const STAGES = [
   {
-    name: 'review',
-    inferRegex:  /-pr-(\d+)$/
-  },
-  {
     name: 'development',
     inferRegex: /-(dev|development|uat|tst|test|qa)$/
   },

--- a/test/lib/infer.js
+++ b/test/lib/infer.js
@@ -5,7 +5,6 @@ let infer = require('../../lib/infer');
 const tests = {
   development: ['www-dev', 'www-development', 'acme-www-development', 'www2-development', 'www-uat', 'www-tst', 'www-test', 'www-qa'],
   staging: ['www-staging', 'www-stg'],
-  review: ['www-pr-123', 'www-staging-pr-123'],
   production: ['www-prod', 'www-production', 'www-admin', 'www-demo', 'www-prd', 'www', 'www-none', 'www-staging2', 'www-pr-preview']
 };
 


### PR DESCRIPTION
We automatically create pipeline associations to review apps when the pipeline is created or when a review app is created in a pipeline.

I believe having this option available in the CLI creates confusion.