### PR TITLE
include link to github diff in output

### DIFF
--- a/commands/pipelines/diff.js
+++ b/commands/pipelines/diff.js
@@ -80,7 +80,8 @@ function* diff(targetApp, downstreamApp, githubToken, herokuUserAgent) {
 
   // Do the actual Github diff
   try {
-    const res = yield cli.got.get(`https://api.github.com/repos/${targetApp.repo}/compare/${downstreamApp.hash}...${targetApp.hash}`, {
+    const path = `${targetApp.repo}/compare/${downstreamApp.hash}...${targetApp.hash}`;
+    const res = yield cli.got.get(`https://api.github.com/repos/${path}`, {
       headers: {
         authorization: 'token ' + githubToken,
         'user-agent': herokuUserAgent
@@ -103,6 +104,7 @@ function* diff(targetApp, downstreamApp, githubToken, herokuUserAgent) {
       {key: 'author', label: 'Author'},
       {key: 'message', label: 'Message'}
     ]});
+    cli.log(`\nhttps://github.com/${path}`);
   } catch (err) {
     cli.hush(err);
     cli.log(`\n${targetApp.name} was not compared to ${downstreamApp.name} because we were unable to perform a diff`);


### PR DESCRIPTION
include link to github diff in output, its common for us to generate that link and paste into hipchat.

```
> h pipelines:diff -a dev-herokuconnect
Fetching apps from pipeline... done
Fetching release info for all apps... done

=== dev-herokuconnect is ahead of herokuconnect-prod-eu by 12 commits
SHA      Date                  Author                 Message
───────  ────────────────────  ─────────────────────  ──────────────────────────────────────────────────────────────────
1788df5  2016-04-01T20:48:46Z  Marc Sibson            Merge pull request #3009 from heroku/doc-instance
2600f8f  2016-04-01T20:28:56Z  Marc Sibson            use INSTANCE as more decriptive than TARGET
c6ebc91  2016-04-01T20:08:03Z  Christopher Lambacher  Merge pull request #3006 from heroku/fix-add-rows-makes-giant-bulk
09ec055  2016-04-01T17:38:22Z  Chris Lambacher        Use a better huristic for bulk row count
d34338e  2016-03-31T23:32:33Z  alouie-sfdc            Merge pull request #2999 from heroku/check-api-after-deploy
eb7de6e  2016-03-31T22:58:23Z  Arthur                 Output timestamp before waiting
9eba8de  2016-03-31T18:30:17Z  Arthur                 Move the API availability check outside of the integration test
18de178  2016-03-31T14:03:22Z  Marty Alchin           Merge pull request #2944 from heroku/mapping-endpoints
f22cefa  2016-03-30T14:13:37Z  Marty Alchin           Remove some mapping details that we aren't yet committing to
32e5f76  2016-03-24T14:48:40Z  Marty Alchin           Better explain what happens on delete
a867535  2016-03-24T14:48:18Z  Marty Alchin           Fix a few typos
2bf80f6  2016-03-22T20:25:22Z  Marty Alchin           Add details of CRUD operations for mappings

https://github.com/heroku/herokuconnect/compare/b1574d83a06f9f376aa7d83ee4747c4d523ede29...1788df5fb2dd0082da9f52e41d1f18a4c7d4924a
```