### PR TITLE
Re-add review apps to pipelines:info

### DIFF
--- a/commands/pipelines/add.js
+++ b/commands/pipelines/add.js
@@ -4,7 +4,7 @@ let cli = require('heroku-cli-util');
 let infer = require('../../lib/infer');
 let disambiguate = require('../../lib/disambiguate');
 let prompt = require('../../lib/prompt');
-let stageNames = require('../../lib/stages').names;
+let stageNames = require('../../lib/stages').inferrableStageNames;
 
 const createCoupling = require('../../lib/api').createCoupling;
 

--- a/commands/pipelines/create.js
+++ b/commands/pipelines/create.js
@@ -4,7 +4,7 @@ let cli = require('heroku-cli-util');
 let co  = require('co');
 let infer = require('../../lib/infer');
 let prompt = require('../../lib/prompt');
-let stages = require('../../lib/stages').names;
+let stages = require('../../lib/stages').inferrableStageNames;
 
 const createCoupling = require('../../lib/api').createCoupling;
 

--- a/commands/pipelines/info.js
+++ b/commands/pipelines/info.js
@@ -2,7 +2,7 @@
 
 const cli             = require('heroku-cli-util');
 const disambiguate    = require('../../lib/disambiguate');
-const stageNames      = require('../../lib/stages').allStageNames;
+const stageNames      = require('../../lib/stages').names;
 const listPipelineApps = require('../../lib/api').listPipelineApps;
 
 module.exports = {

--- a/commands/pipelines/info.js
+++ b/commands/pipelines/info.js
@@ -2,7 +2,7 @@
 
 const cli             = require('heroku-cli-util');
 const disambiguate    = require('../../lib/disambiguate');
-const stageNames      = require('../../lib/stages').names;
+const stageNames      = require('../../lib/stages').allStageNames;
 const listPipelineApps = require('../../lib/api').listPipelineApps;
 
 module.exports = {

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stages = require('./stages').stages;
+const stages = require('./stages').inferrableStages;
 
 module.exports = function infer(app) {
   const inferredStage = stages.find(stage => stage.inferRegex.test(app));

--- a/lib/stages.js
+++ b/lib/stages.js
@@ -1,4 +1,4 @@
-const STAGES = [
+const INFERRABLE_STAGES = [
   {
     name: 'development',
     inferRegex: /-(dev|development|uat|tst|test|qa)$/
@@ -13,9 +13,9 @@ const STAGES = [
   }
 ];
 
-const STAGE_NAMES     = STAGES.map((stage) => stage.name);
-const ALL_STAGE_NAMES = ['review'].concat(STAGE_NAMES);
+const INFERRABLE_STAGE_NAMES = INFERRABLE_STAGES.map((stage) => stage.name);
+const STAGE_NAMES = ['review'].concat(INFERRABLE_STAGE_NAMES);
 
-exports.stages        = STAGES;
-exports.names         = STAGE_NAMES;
-exports.allStageNames = ALL_STAGE_NAMES;
+exports.inferrableStages = INFERRABLE_STAGES;
+exports.inferrableStageNames = INFERRABLE_STAGE_NAMES;
+exports.names = STAGE_NAMES;

--- a/lib/stages.js
+++ b/lib/stages.js
@@ -13,5 +13,9 @@ const STAGES = [
   }
 ];
 
-exports.stages = STAGES;
-exports.names  = STAGES.map((stage) => stage.name);
+const STAGE_NAMES     = STAGES.map((stage) => stage.name);
+const ALL_STAGE_NAMES = ['review'].concat(STAGE_NAMES);
+
+exports.stages        = STAGES;
+exports.names         = STAGE_NAMES;
+exports.allStageNames = ALL_STAGE_NAMES;


### PR DESCRIPTION
It seems that when #22 was merged, `pipelines:info` stopped showing review apps being a part of the pipeline.

This change addresses that by bringing them back.