### PR TITLE
Stop using 3.pipelines variant

### DIFF
--- a/lib/disambiguate.js
+++ b/lib/disambiguate.js
@@ -9,13 +9,13 @@ function *disambiguate(heroku, pipeline_id_or_name) {
     pipeline = yield heroku.request({
       method: 'GET',
       path: `/pipelines/${pipeline_id_or_name}`,
-      headers: { 'Accept': 'application/vnd.heroku+json; version=3.pipelines' }
+      headers: { 'Accept': 'application/vnd.heroku+json; version=3' }
     }); // heroku.pipelines(pipeline_id_or_name).info();
   } else {
     let pipelines = yield heroku.request({
       method: 'GET',
       path: `/pipelines?eq[name]=${pipeline_id_or_name}`,
-      headers: { 'Accept': 'application/vnd.heroku+json; version=3.pipelines' }
+      headers: { 'Accept': 'application/vnd.heroku+json; version=3' }
     });
     if(pipelines.length === 0) {
       throw new Error('Pipeline not found');

--- a/lib/disambiguate.js
+++ b/lib/disambiguate.js
@@ -6,10 +6,7 @@ let inquirer  = require("inquirer");
 function *disambiguate(heroku, pipeline_id_or_name) {
   var pipeline;
   if(validator.isUUID(pipeline_id_or_name)) {
-    pipeline = yield heroku.request({
-      method: 'GET',
-      path: `/pipelines/${pipeline_id_or_name}`
-    }); // heroku.pipelines(pipeline_id_or_name).info();
+    pipeline = yield heroku.pipelines(pipeline_id_or_name).info();
   } else {
     let pipelines = yield heroku.request({
       method: 'GET',

--- a/lib/disambiguate.js
+++ b/lib/disambiguate.js
@@ -8,14 +8,12 @@ function *disambiguate(heroku, pipeline_id_or_name) {
   if(validator.isUUID(pipeline_id_or_name)) {
     pipeline = yield heroku.request({
       method: 'GET',
-      path: `/pipelines/${pipeline_id_or_name}`,
-      headers: { 'Accept': 'application/vnd.heroku+json; version=3' }
+      path: `/pipelines/${pipeline_id_or_name}`
     }); // heroku.pipelines(pipeline_id_or_name).info();
   } else {
     let pipelines = yield heroku.request({
       method: 'GET',
-      path: `/pipelines?eq[name]=${pipeline_id_or_name}`,
-      headers: { 'Accept': 'application/vnd.heroku+json; version=3' }
+      path: `/pipelines?eq[name]=${pipeline_id_or_name}`
     });
     if(pipelines.length === 0) {
       throw new Error('Pipeline not found');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bluebird": "3.3.4",
     "co": "4.6.0",
-    "heroku-cli-util": "5.9.3",
+    "heroku-cli-util": "5.10.10",
     "inflection": "1.8.0",
     "inquirer": "0.12.0",
     "string-just": "0.0.2",


### PR DESCRIPTION
Removes the last remaining references to the `3.pipelines` API variant. The motivation for this is to clear out deprecation noise in the server side logs.