### PR TITLE
Explicit 2FA check on promotion endpoint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,7 @@
   "laxcomma": true,
   "maxcomplexity": 10,
   "maxdepth": 5,
-  "maxparams": 5,
+  "maxparams": 6,
   "maxstatements": 25,
   "multistr": true,
   "newcap": true,


### PR DESCRIPTION
Currently the promotion endpoint can fail for apps which require 2FA because it re-runs all requests after prompting for a second factor. If the supplied second factor is counter based (e.g. a yubikey) then it expires after the first request.

This change explicitly wraps the only request which may require 2FA and retries it if necessary.