### PR TITLE
Fix typo in help string

### DIFF
--- a/commands/pipelines/diff.js
+++ b/commands/pipelines/diff.js
@@ -175,7 +175,7 @@ function* run(context, heroku) {
 module.exports = {
   topic: 'pipelines',
   command: 'diff',
-  description: 'compares the latest release of this app its downstream app(s)',
+  description: 'compares the latest release of this app to its downstream app(s)',
   needsAuth: true,
   needsApp: true,
   run: cli.command(co.wrap(run))


### PR DESCRIPTION
Just a small fix to the wording of `pipelines:diff`'s help string.