### PR TITLE
heroku pipelines:setup command

### DIFF
--- a/commands/pipelines/create.js
+++ b/commands/pipelines/create.js
@@ -2,6 +2,7 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
+let api = require('../../lib/api')
 let infer = require('../../lib/infer')
 let prompt = require('../../lib/prompt')
 let stages = require('../../lib/stages').inferrableStageNames
@@ -39,12 +40,7 @@ function* run (context, heroku) {
   let answers = yield prompt(questions)
   if (answers.name) name = answers.name
   if (answers.stage) stage = answers.stage
-  let promise = heroku.request({
-    method: 'POST',
-    path: '/pipelines',
-    body: {name: name},
-    headers: { 'Accept': 'application/vnd.heroku+json; version=3' }
-  }) // heroku.pipelines().create({name: name});
+  let promise = api.createPipeline(heroku, name)
   let pipeline = yield cli.action(`Creating ${name} pipeline`, promise)
 
   yield cli.action(`Adding ${app} to ${pipeline.name} pipeline as ${stage}`,

--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -209,6 +209,6 @@ module.exports = {
       setupPipeline(herokuToken, stagingApp.id, settings, pipeline.id, ciSettings)
     )
 
-    cli.log(`View your new pipeline by running \`heroku pipelines:open ${pipeline.id}\``)
+    yield cli.open(`https://dashboard.heroku.com/pipelines/${pipeline.id}`)
   }))
 }

--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -130,13 +130,14 @@ module.exports = {
     const archiveURL = yield github.getArchiveURL(githubToken, repoName, repo.default_branch)
 
     yield cli.action(
-      'Creating production app',
+      `Creating ${cli.color.app(pipelineName)} (production app)`,
       createApp(heroku, archiveURL, pipelineName, pipeline, 'production')
     )
 
+    const stagingAppName = `${pipelineName}-staging`
     const stagingApp = yield cli.action(
-      'Creating staging app',
-      createApp(heroku, archiveURL, `${pipelineName}-staging`, pipeline, 'staging')
+      `Creating ${cli.color.app(stagingAppName)} (staging app)`,
+      createApp(heroku, archiveURL, stagingAppName, pipeline, 'staging')
     )
 
     yield cli.action(

--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -2,11 +2,10 @@
 
 const cli = require('heroku-cli-util');
 const co  = require('co');
+const api = require('../../lib/api');
 const kolkrabbi = require('../../lib/kolkrabbi-api');
 const github = require('../../lib/github-api');
 const prompt = require('../../lib/prompt');
-
-const createCoupling = require('../../lib/api').createCoupling;
 
 function* getPipelineName(context) {
   return context.args.name || (yield prompt([
@@ -37,7 +36,7 @@ function* getGithubAccount(token) {
     // TODO: Allow user to conect here
     throw new Error('Account not connected to GitHub.');
   }
-  return githubAccount
+  return githubAccount;
 }
 
 function* getRepo(name, token) {
@@ -46,10 +45,56 @@ function* getRepo(name, token) {
   try {
     repo = yield github.getRepo(name, token);
   } catch(error) {
-    throw new Error(`Could not access ${repoName}`);
+    throw new Error(`Could not access ${name}`);
   }
 
   return repo;
+}
+
+function createApp(heroku, archiveURL, name, pipeline, stage) {
+  return api.createAppSetup(heroku, {
+    source_blob: { url: archiveURL },
+    app: { name }
+  }).then((setup) => {
+    return api.postCoupling(heroku, pipeline.id, setup.app.id, stage).then(() => {
+      return setup.app;
+    });
+  });
+}
+
+function* getSettings(branch) {
+  return yield prompt([{
+    type: 'confirm',
+    name: 'auto_deploy',
+    message: `Automatically deploy the ${branch} branch to staging?`
+  }, {
+    type: 'confirm',
+    name: 'wait_for_ci',
+    message: `Wait for CI to pass before deploying the ${branch} branch to staging?`,
+    when(answers) { return answers.auto_deploy; }
+  }, {
+    type: 'confirm',
+    name: 'pull_requests.enabled',
+    message: 'Enable review apps?'
+  }, {
+    type: 'confirm',
+    name: 'pull_requests.auto_deploy',
+    message: 'Automatically create review apps for every PR?',
+    when(answers) { return answers.pull_requests.enabled; }
+  }, {
+    type: 'confirm',
+    name: 'pull_requests.auto_destroy',
+    message: 'Automatically destroy idle review apps after 5 days?',
+    when(answers) { return answers.pull_requests.enabled; }
+  }]);
+}
+
+function setupPipeline(token, app, settings) {
+  return kolkrabbi.updateAppLink(token, app, settings).then((appLink) => {
+    return appLink;
+  }, (error) => {
+    cli.error(error.response.body.message);
+  });
 }
 
 module.exports = {
@@ -71,26 +116,26 @@ module.exports = {
       optional: true
     }
   ],
-  flags: [
-    {
-      name: 'stage',
-      char: 's', description:
-      'stage of first app in pipeline',
-      hasValue: true
-    }
-  ],
   run: cli.command(co.wrap(function*(context, heroku) {
+    //TODO: Allow -o flag
     const pipelineName  = yield getPipelineName(context);
     const repoName      = yield getRepoName(context);
     const githubAccount = yield getGithubAccount(heroku.options.token);
-    const repo          = yield getRepo(repoName, githubAccount.github.token);
+    const githubToken   = githubAccount.github.token;
+    const repo          = yield getRepo(githubToken, repoName);
 
-    // Create pipeline
-    // Connect pipeline to GitHub
-    // Create production app via /app-setups
-    // Create staging app via /app-setups
-    // Enable review apps
-    // Enable CI auto runs if user is flagged in
-    // Open dashboard on the new pipeline
+    const pipeline     = yield cli.action('Creating pipeline', api.createPipeline(heroku, pipelineName));
+    yield cli.action('Linking to repo', kolkrabbi.createPipelineRepository(heroku.options.token, pipeline.id, repo.id));
+    const archiveURL   = yield github.getArchiveURL(githubToken, repoName, repo.default_branch);
+
+    yield cli.action('Creating production app', createApp(heroku, archiveURL, pipelineName, pipeline, 'production'));
+    const stagingApp    = yield cli.action('Creating staging app', createApp(heroku, archiveURL, `${pipelineName}-staging`, pipeline, 'staging'));
+
+    const settings = yield getSettings(repo.default_branch);
+    yield cli.action('Configuring pipeline', setupPipeline(heroku.options.token, stagingApp.id, settings));
+
+    // TODO: enable CI
+
+    yield cli.open(`https://dashboard.heroku.com/pipelines/${pipeline.id}`);
   }))
 };

--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -129,7 +129,7 @@ function setupPipeline (token, app, settings, pipelineID, ciSettings = {}) {
 module.exports = {
   topic: 'pipelines',
   command: 'setup',
-  description: 'bootstrap a new pipeline with common settings',
+  description: 'bootstrap a new pipeline with common settings and create a production and staging app (requires a fully formed app.json in the repo)',
   help: `Example:
 
   heroku pipelines:setup example githuborg/reponame -o example-org
@@ -162,13 +162,13 @@ module.exports = {
     {
       name: 'organization',
       char: 'o',
-      description: 'the organization which will own the apps (aliased as --team)',
+      description: 'the organization which will own the apps (can also use --team)',
       hasValue: true
     },
     {
       name: 'team',
       char: 't',
-      description: 'the team which will own the apps (aliased as --organization)',
+      description: 'the team which will own the apps (can also use --organization)',
       hasValue: true
     }
   ],

--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const cli = require('heroku-cli-util');
+const co  = require('co');
+const kolkrabbi = require('../../lib/kolkrabbi-api');
+const github = require('../../lib/github-api');
+const prompt = require('../../lib/prompt');
+
+const createCoupling = require('../../lib/api').createCoupling;
+
+function* getPipelineName(context) {
+  return context.args.name || (yield prompt([
+    {
+      type: 'input',
+      name: 'name',
+      message: 'Pipeline name'
+    }
+  ])).name;
+}
+
+function* getRepoName(context) {
+  return context.args.repo || (yield prompt([
+    {
+      type: 'input',
+      name: 'repo',
+      message: 'GitHub repository to connect to (e.g. rails/rails)'
+    }
+  ])).repo;
+}
+
+function* getGithubAccount(token) {
+  let githubAccount;
+
+  try {
+    githubAccount = yield kolkrabbi.getAccount(token);
+  } catch(error) {
+    // TODO: Allow user to conect here
+    throw new Error('Account not connected to GitHub.');
+  }
+  return githubAccount
+}
+
+function* getRepo(name, token) {
+  let repo;
+
+  try {
+    repo = yield github.getRepo(name, token);
+  } catch(error) {
+    throw new Error(`Could not access ${repoName}`);
+  }
+
+  return repo;
+}
+
+module.exports = {
+  topic: 'pipelines',
+  command: 'setup',
+  description: 'bootstrap a new pipeline with common settings',
+  help: 'create a new pipeline and set up common features such as review apps',
+  needsApp: false,
+  needsAuth: true,
+  args: [
+    {
+      name: 'name',
+      description: 'name of pipeline',
+      optional: true
+    },
+    {
+      name: 'repo',
+      description: 'a GitHub repository to connect the pipeline to',
+      optional: true
+    }
+  ],
+  flags: [
+    {
+      name: 'stage',
+      char: 's', description:
+      'stage of first app in pipeline',
+      hasValue: true
+    }
+  ],
+  run: cli.command(co.wrap(function*(context, heroku) {
+    const pipelineName  = yield getPipelineName(context);
+    const repoName      = yield getRepoName(context);
+    const githubAccount = yield getGithubAccount(heroku.options.token);
+    const repo          = yield getRepo(repoName, githubAccount.github.token);
+
+    // Create pipeline
+    // Connect pipeline to GitHub
+    // Create production app via /app-setups
+    // Create staging app via /app-setups
+    // Enable review apps
+    // Enable CI auto runs if user is flagged in
+    // Open dashboard on the new pipeline
+  }))
+};

--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -1,68 +1,68 @@
-'use strict';
+'use strict'
 
-const cli = require('heroku-cli-util');
-const co  = require('co');
-const api = require('../../lib/api');
-const kolkrabbi = require('../../lib/kolkrabbi-api');
-const github = require('../../lib/github-api');
-const prompt = require('../../lib/prompt');
+const cli = require('heroku-cli-util')
+const co = require('co')
+const api = require('../../lib/api')
+const kolkrabbi = require('../../lib/kolkrabbi-api')
+const github = require('../../lib/github-api')
+const prompt = require('../../lib/prompt')
 
-function* getPipelineName(context) {
+function* getPipelineName (context) {
   return context.args.name || (yield prompt([
     {
       type: 'input',
       name: 'name',
       message: 'Pipeline name'
     }
-  ])).name;
+  ])).name
 }
 
-function* getRepoName(context) {
+function* getRepoName (context) {
   return context.args.repo || (yield prompt([
     {
       type: 'input',
       name: 'repo',
       message: 'GitHub repository to connect to (e.g. rails/rails)'
     }
-  ])).repo;
+  ])).repo
 }
 
-function* getGithubAccount(token) {
-  let githubAccount;
+function* getGithubAccount (token) {
+  let githubAccount
 
   try {
-    githubAccount = yield kolkrabbi.getAccount(token);
-  } catch(error) {
+    githubAccount = yield kolkrabbi.getAccount(token)
+  } catch (error) {
     // TODO: Allow user to conect here
-    throw new Error('Account not connected to GitHub.');
+    throw new Error('Account not connected to GitHub.')
   }
-  return githubAccount;
+  return githubAccount
 }
 
-function* getRepo(name, token) {
-  let repo;
+function* getRepo (name, token) {
+  let repo
 
   try {
-    repo = yield github.getRepo(name, token);
-  } catch(error) {
-    throw new Error(`Could not access ${name}`);
+    repo = yield github.getRepo(name, token)
+  } catch (error) {
+    throw new Error(`Could not access ${name}`)
   }
 
-  return repo;
+  return repo
 }
 
-function createApp(heroku, archiveURL, name, pipeline, stage) {
+function createApp (heroku, archiveURL, name, pipeline, stage) {
   return api.createAppSetup(heroku, {
     source_blob: { url: archiveURL },
     app: { name }
   }).then((setup) => {
     return api.postCoupling(heroku, pipeline.id, setup.app.id, stage).then(() => {
-      return setup.app;
-    });
-  });
+      return setup.app
+    })
+  })
 }
 
-function* getSettings(branch) {
+function* getSettings (branch) {
   return yield prompt([{
     type: 'confirm',
     name: 'auto_deploy',
@@ -71,7 +71,7 @@ function* getSettings(branch) {
     type: 'confirm',
     name: 'wait_for_ci',
     message: `Wait for CI to pass before deploying the ${branch} branch to staging?`,
-    when(answers) { return answers.auto_deploy; }
+    when (answers) { return answers.auto_deploy }
   }, {
     type: 'confirm',
     name: 'pull_requests.enabled',
@@ -80,21 +80,21 @@ function* getSettings(branch) {
     type: 'confirm',
     name: 'pull_requests.auto_deploy',
     message: 'Automatically create review apps for every PR?',
-    when(answers) { return answers.pull_requests.enabled; }
+    when (answers) { return answers.pull_requests.enabled }
   }, {
     type: 'confirm',
     name: 'pull_requests.auto_destroy',
     message: 'Automatically destroy idle review apps after 5 days?',
-    when(answers) { return answers.pull_requests.enabled; }
-  }]);
+    when (answers) { return answers.pull_requests.enabled }
+  }])
 }
 
-function setupPipeline(token, app, settings) {
+function setupPipeline (token, app, settings) {
   return kolkrabbi.updateAppLink(token, app, settings).then((appLink) => {
-    return appLink;
+    return appLink
   }, (error) => {
-    cli.error(error.response.body.message);
-  });
+    cli.error(error.response.body.message)
+  })
 }
 
 module.exports = {
@@ -117,25 +117,37 @@ module.exports = {
     }
   ],
   run: cli.command(co.wrap(function*(context, heroku) {
-    //TODO: Allow -o flag
-    const pipelineName  = yield getPipelineName(context);
-    const repoName      = yield getRepoName(context);
-    const githubAccount = yield getGithubAccount(heroku.options.token);
-    const githubToken   = githubAccount.github.token;
-    const repo          = yield getRepo(githubToken, repoName);
+    // TODO: Allow -o flag
+    const pipelineName = yield getPipelineName(context)
+    const repoName = yield getRepoName(context)
+    const githubAccount = yield getGithubAccount(heroku.options.token)
+    const githubToken = githubAccount.github.token
+    const repo = yield getRepo(githubToken, repoName)
 
-    const pipeline     = yield cli.action('Creating pipeline', api.createPipeline(heroku, pipelineName));
-    yield cli.action('Linking to repo', kolkrabbi.createPipelineRepository(heroku.options.token, pipeline.id, repo.id));
-    const archiveURL   = yield github.getArchiveURL(githubToken, repoName, repo.default_branch);
+    const pipeline = yield cli.action('Creating pipeline', api.createPipeline(heroku, pipelineName))
+    yield cli.action(
+      'Linking to repo',
+      kolkrabbi.createPipelineRepository(heroku.options.token, pipeline.id, repo.id)
+    )
+    const archiveURL = yield github.getArchiveURL(githubToken, repoName, repo.default_branch)
 
-    yield cli.action('Creating production app', createApp(heroku, archiveURL, pipelineName, pipeline, 'production'));
-    const stagingApp    = yield cli.action('Creating staging app', createApp(heroku, archiveURL, `${pipelineName}-staging`, pipeline, 'staging'));
+    yield cli.action(
+      'Creating production app',
+      createApp(heroku, archiveURL, pipelineName, pipeline, 'production')
+    )
+    const stagingApp = yield cli.action(
+      'Creating staging app',
+      createApp(heroku, archiveURL, `${pipelineName}-staging`, pipeline, 'staging')
+    )
 
-    const settings = yield getSettings(repo.default_branch);
-    yield cli.action('Configuring pipeline', setupPipeline(heroku.options.token, stagingApp.id, settings));
+    const settings = yield getSettings(repo.default_branch)
+    yield cli.action(
+      'Configuring pipeline',
+      setupPipeline(heroku.options.token, stagingApp.id, settings)
+    )
 
     // TODO: enable CI
 
-    yield cli.open(`https://dashboard.heroku.com/pipelines/${pipeline.id}`);
+    cli.log(`Done. Your new pipeline can be viewed at https://dashboard.heroku.com/pipelines/${pipeline.id}`)
   }))
-};
+}

--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -145,6 +145,6 @@ module.exports = {
       setupPipeline(herokuToken, stagingApp.id, settings)
     )
 
-    cli.log(`View your new pipeline at https://dashboard.heroku.com/pipelines/${pipeline.id}`)
+    cli.log(`View your new pipeline by running \`heroku pipelines:open ${pipeline.id}\``)
   }))
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -59,6 +59,21 @@ function listCouplings (heroku, pipelineId) {
   })
 }
 
+function getPipeline (heroku, id) {
+  return heroku.request({
+    method: 'GET',
+    path: `/pipelines/${id}`,
+    headers: { Accept: V3_HEADER }
+  })
+}
+
+function findPipelineByName (heroku, idOrnName) {
+  return heroku.request({
+    method: 'GET',
+    path: `/pipelines?eq[name]=${idOrnName}`
+  })
+}
+
 function createPipeline (heroku, name) {
   return heroku.request({
     method: 'POST',
@@ -109,6 +124,8 @@ exports.updateCoupling = updateCoupling
 exports.removeCoupling = removeCoupling
 exports.listCouplings = listCouplings
 
+exports.getPipeline = getPipeline
+exports.findPipelineByName = findPipelineByName
 exports.createPipeline = createPipeline
 
 exports.createAppSetup = createAppSetup

--- a/lib/api.js
+++ b/lib/api.js
@@ -59,6 +59,24 @@ function listCouplings (heroku, pipelineId) {
   })
 }
 
+function createPipeline (heroku, name) {
+  return heroku.request({
+    method: 'POST',
+    path: '/pipelines',
+    headers: { 'Accept': V3_HEADER },
+    body: { name }
+  })
+}
+
+function createAppSetup (heroku, body) {
+  return heroku.request({
+    method: 'POST',
+    path: '/app-setups',
+    headers: { 'Accept': V3_HEADER },
+    body
+  })
+}
+
 function getAppFilter (heroku, appIds) {
   return heroku.request({
     method: 'POST',
@@ -89,8 +107,11 @@ exports.deleteCoupling = deleteCoupling
 exports.createCoupling = createCoupling
 exports.updateCoupling = updateCoupling
 exports.removeCoupling = removeCoupling
-
 exports.listCouplings = listCouplings
+
+exports.createPipeline = createPipeline
+
+exports.createAppSetup = createAppSetup
 
 exports.getAppFilter = getAppFilter
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -114,6 +114,14 @@ function listPipelineApps (heroku, pipelineId) {
   })
 }
 
+function getAccountFeature (heroku, feature) {
+  return heroku.request({
+    method: 'GET',
+    path: `/account/features/${feature}`,
+    headers: { Accept: V3_HEADER }
+  })
+}
+
 exports.getCoupling = getCoupling
 exports.postCoupling = postCoupling
 exports.patchCoupling = patchCoupling
@@ -133,5 +141,7 @@ exports.createAppSetup = createAppSetup
 exports.getAppFilter = getAppFilter
 
 exports.listPipelineApps = listPipelineApps
+
+exports.getAccountFeature = getAccountFeature
 
 exports.V3_HEADER = V3_HEADER

--- a/lib/disambiguate.js
+++ b/lib/disambiguate.js
@@ -2,16 +2,14 @@
 
 let validator = require('validator')
 let inquirer = require('inquirer')
+let api = require('./api')
 
 function* disambiguate (heroku, pipelineIDOrName) {
   var pipeline
   if (validator.isUUID(pipelineIDOrName)) {
-    pipeline = yield heroku.pipelines(pipelineIDOrName).info()
+    pipeline = yield api.getPipeline(heroku, pipelineIDOrName)
   } else {
-    let pipelines = yield heroku.request({
-      method: 'GET',
-      path: `/pipelines?eq[name]=${pipelineIDOrName}`
-    })
+    let pipelines = yield api.findPipelineByName(heroku, pipelineIDOrName)
     if (pipelines.length === 0) {
       throw new Error('Pipeline not found')
     } else if (pipelines.length === 1) {

--- a/lib/github-api.js
+++ b/lib/github-api.js
@@ -1,26 +1,26 @@
-const cli = require('heroku-cli-util');
-const GITHUB_API = 'https://api.github.com';
+const cli = require('heroku-cli-util')
+const GITHUB_API = 'https://api.github.com'
 
-function request(url, token, options = {}) {
+function request (url, token, options = {}) {
   options = Object.assign({
     headers: {
       Authorization: `Token ${token}`
     },
     json: true
-  }, options);
+  }, options)
 
-  return cli.got.get(`${GITHUB_API}${url}`, options);
+  return cli.got.get(`${GITHUB_API}${url}`, options)
 }
 
-function getRepo(token, name) {
-  return request(`/repos/${name}`, token).then((res) => res.body);
+function getRepo (token, name) {
+  return request(`/repos/${name}`, token).then((res) => res.body)
 }
 
-function getArchiveURL(token, repo, ref) {
+function getArchiveURL (token, repo, ref) {
   return request(`/repos/${repo}/tarball/${ref}`, token, {
     followRedirect: false
-  }).then((res) => res.headers.location);
+  }).then((res) => res.headers.location)
 }
 
-module.exports.getRepo = getRepo;
-module.exports.getArchiveURL = getArchiveURL;
+module.exports.getRepo = getRepo
+module.exports.getArchiveURL = getArchiveURL

--- a/lib/github-api.js
+++ b/lib/github-api.js
@@ -1,16 +1,26 @@
-const got = require('got');
+const cli = require('heroku-cli-util');
 const GITHUB_API = 'https://api.github.com';
 
-function request(url, token) {
-  return got.get(`${GITHUB_API}${url}`, {
+function request(url, token, options = {}) {
+  options = Object.assign({
     headers: {
       Authorization: `Token ${token}`
-    }
-  });
+    },
+    json: true
+  }, options);
+
+  return cli.got.get(`${GITHUB_API}${url}`, options);
 }
 
-function getRepo(name, token) {
-  return request(`/repos/${name}`, token);
+function getRepo(token, name) {
+  return request(`/repos/${name}`, token).then((res) => res.body);
+}
+
+function getArchiveURL(token, repo, ref) {
+  return request(`/repos/${repo}/tarball/${ref}`, token, {
+    followRedirect: false
+  }).then((res) => res.headers.location);
 }
 
 module.exports.getRepo = getRepo;
+module.exports.getArchiveURL = getArchiveURL;

--- a/lib/github-api.js
+++ b/lib/github-api.js
@@ -1,26 +1,30 @@
 const cli = require('heroku-cli-util')
 const GITHUB_API = 'https://api.github.com'
 
-function request (url, token, options = {}) {
-  options = Object.assign({
-    headers: {
-      Authorization: `Token ${token}`
-    },
-    json: true
-  }, options)
+module.exports = class GitHubAPI {
+  constructor (version, token) {
+    this.version = version
+    this.token = token
+  }
 
-  return cli.got.get(`${GITHUB_API}${url}`, options)
+  request (url, options = {}) {
+    options.headers = Object.assign({
+      Authorization: `Token ${this.token}`,
+      'User-Agent': this.version
+    }, options.headers)
+
+    options.json = true
+
+    return cli.got.get(`${GITHUB_API}${url}`, options)
+  }
+
+  getRepo (name) {
+    return this.request(`/repos/${name}`).then((res) => res.body)
+  }
+
+  getArchiveURL (repo, ref) {
+    return this.request(`/repos/${repo}/tarball/${ref}`, {
+      followRedirect: false
+    }).then((res) => res.headers.location)
+  }
 }
-
-function getRepo (token, name) {
-  return request(`/repos/${name}`, token).then((res) => res.body)
-}
-
-function getArchiveURL (token, repo, ref) {
-  return request(`/repos/${repo}/tarball/${ref}`, token, {
-    followRedirect: false
-  }).then((res) => res.headers.location)
-}
-
-module.exports.getRepo = getRepo
-module.exports.getArchiveURL = getArchiveURL

--- a/lib/github-api.js
+++ b/lib/github-api.js
@@ -1,0 +1,16 @@
+const got = require('got');
+const GITHUB_API = 'https://api.github.com';
+
+function request(url, token) {
+  return got.get(`${GITHUB_API}${url}`, {
+    headers: {
+      Authorization: `Token ${token}`
+    }
+  });
+}
+
+function getRepo(name, token) {
+  return request(`/repos/${name}`, token);
+}
+
+module.exports.getRepo = getRepo;

--- a/lib/kolkrabbi-api.js
+++ b/lib/kolkrabbi-api.js
@@ -1,17 +1,44 @@
 const cli = require('heroku-cli-util');
 const KOLKRABBI_BASE_URL = 'https://kolkrabbi.heroku.com';
 
-function kolkrabbiRequest(url, token) {
-  return cli.got.get(KOLKRABBI_BASE_URL + url, {
-    headers: {
-      authorization: 'Bearer ' + token
-    },
-    json: true
-  }).then(res => res.body);
+function kolkrabbiRequest(url, token, options = {}) {
+  if (options.body) {
+    options.body = JSON.stringify(options.body);
+  }
+
+  if (!options.headers) {
+    options.headers = {};
+  }
+
+  options.headers.authorization = `Bearer ${token}`;
+
+  if (['POST', 'PATCH', 'DELETE'].includes(options.method)) {
+    options.headers['Content-type'] = 'application/json';
+  }
+
+  options = Object.assign({ json: true }, options);
+
+  return cli.got(KOLKRABBI_BASE_URL + url, options).then((res) => res.body);
 }
 
 function getAccount(token) {
   return kolkrabbiRequest('/account/github/token', token);
 }
 
+function createPipelineRepository(token, pipeline, repository) {
+  return kolkrabbiRequest(`/pipelines/${pipeline}/repository`, token, {
+    method: 'POST',
+    body: { repository }
+  });
+}
+
+function updateAppLink(token, app, body) {
+  return kolkrabbiRequest(`/apps/${app}/github`, token, {
+    method: 'PATCH',
+    body
+  });
+}
+
 module.exports.getAccount = getAccount;
+module.exports.createPipelineRepository = createPipelineRepository;
+module.exports.updateAppLink = updateAppLink;

--- a/lib/kolkrabbi-api.js
+++ b/lib/kolkrabbi-api.js
@@ -1,52 +1,53 @@
 const cli = require('heroku-cli-util')
 const KOLKRABBI_BASE_URL = 'https://kolkrabbi.heroku.com'
 
-function kolkrabbiRequest (url, token, options = {}) {
-  if (options.body) {
-    options.body = JSON.stringify(options.body)
+module.exports = class KolkrabbiAPI {
+  constructor (version, token) {
+    this.version = version
+    this.token = token
   }
 
-  if (!options.headers) {
-    options.headers = {}
+  request (url, options = {}) {
+    if (options.body) {
+      options.body = JSON.stringify(options.body)
+    }
+
+    options.headers = Object.assign({
+      Authorization: `Bearer ${this.token}`,
+      'User-Agent': this.version
+    })
+
+    if (['POST', 'PATCH', 'DELETE'].includes(options.method)) {
+      options.headers['Content-type'] = 'application/json'
+    }
+
+    options.json = true
+
+    return cli.got(KOLKRABBI_BASE_URL + url, options).then((res) => res.body)
   }
 
-  options.headers.authorization = `Bearer ${token}`
-
-  if (['POST', 'PATCH', 'DELETE'].includes(options.method)) {
-    options.headers['Content-type'] = 'application/json'
+  getAccount () {
+    return this.request('/account/github/token')
   }
 
-  options = Object.assign({ json: true }, options)
+  createPipelineRepository (pipeline, repository) {
+    return this.request(`/pipelines/${pipeline}/repository`, {
+      method: 'POST',
+      body: { repository }
+    })
+  }
 
-  return cli.got(KOLKRABBI_BASE_URL + url, options).then((res) => res.body)
+  updatePipelineRepository (pipeline, body) {
+    return this.request(`/pipelines/${pipeline}/repository`, {
+      method: 'PATCH',
+      body
+    })
+  }
+
+  updateAppLink (app, body) {
+    return this.request(`/apps/${app}/github`, {
+      method: 'PATCH',
+      body
+    })
+  }
 }
-
-function getAccount (token) {
-  return kolkrabbiRequest('/account/github/token', token)
-}
-
-function createPipelineRepository (token, pipeline, repository) {
-  return kolkrabbiRequest(`/pipelines/${pipeline}/repository`, token, {
-    method: 'POST',
-    body: { repository }
-  })
-}
-
-function updatePipelineRepository (token, pipeline, body) {
-  return kolkrabbiRequest(`/pipelines/${pipeline}/repository`, token, {
-    method: 'PATCH',
-    body
-  })
-}
-
-function updateAppLink (token, app, body) {
-  return kolkrabbiRequest(`/apps/${app}/github`, token, {
-    method: 'PATCH',
-    body
-  })
-}
-
-module.exports.getAccount = getAccount
-module.exports.createPipelineRepository = createPipelineRepository
-module.exports.updatePipelineRepository = updatePipelineRepository
-module.exports.updateAppLink = updateAppLink

--- a/lib/kolkrabbi-api.js
+++ b/lib/kolkrabbi-api.js
@@ -1,0 +1,17 @@
+const cli = require('heroku-cli-util');
+const KOLKRABBI_BASE_URL = 'https://kolkrabbi.heroku.com';
+
+function kolkrabbiRequest(url, token) {
+  return cli.got.get(KOLKRABBI_BASE_URL + url, {
+    headers: {
+      authorization: 'Bearer ' + token
+    },
+    json: true
+  }).then(res => res.body);
+}
+
+function getAccount(token) {
+  return kolkrabbiRequest('/account/github/token', token);
+}
+
+module.exports.getAccount = getAccount;

--- a/lib/kolkrabbi-api.js
+++ b/lib/kolkrabbi-api.js
@@ -1,44 +1,44 @@
-const cli = require('heroku-cli-util');
-const KOLKRABBI_BASE_URL = 'https://kolkrabbi.heroku.com';
+const cli = require('heroku-cli-util')
+const KOLKRABBI_BASE_URL = 'https://kolkrabbi.heroku.com'
 
-function kolkrabbiRequest(url, token, options = {}) {
+function kolkrabbiRequest (url, token, options = {}) {
   if (options.body) {
-    options.body = JSON.stringify(options.body);
+    options.body = JSON.stringify(options.body)
   }
 
   if (!options.headers) {
-    options.headers = {};
+    options.headers = {}
   }
 
-  options.headers.authorization = `Bearer ${token}`;
+  options.headers.authorization = `Bearer ${token}`
 
   if (['POST', 'PATCH', 'DELETE'].includes(options.method)) {
-    options.headers['Content-type'] = 'application/json';
+    options.headers['Content-type'] = 'application/json'
   }
 
-  options = Object.assign({ json: true }, options);
+  options = Object.assign({ json: true }, options)
 
-  return cli.got(KOLKRABBI_BASE_URL + url, options).then((res) => res.body);
+  return cli.got(KOLKRABBI_BASE_URL + url, options).then((res) => res.body)
 }
 
-function getAccount(token) {
-  return kolkrabbiRequest('/account/github/token', token);
+function getAccount (token) {
+  return kolkrabbiRequest('/account/github/token', token)
 }
 
-function createPipelineRepository(token, pipeline, repository) {
+function createPipelineRepository (token, pipeline, repository) {
   return kolkrabbiRequest(`/pipelines/${pipeline}/repository`, token, {
     method: 'POST',
     body: { repository }
-  });
+  })
 }
 
-function updateAppLink(token, app, body) {
+function updateAppLink (token, app, body) {
   return kolkrabbiRequest(`/apps/${app}/github`, token, {
     method: 'PATCH',
     body
-  });
+  })
 }
 
-module.exports.getAccount = getAccount;
-module.exports.createPipelineRepository = createPipelineRepository;
-module.exports.updateAppLink = updateAppLink;
+module.exports.getAccount = getAccount
+module.exports.createPipelineRepository = createPipelineRepository
+module.exports.updateAppLink = updateAppLink

--- a/lib/kolkrabbi-api.js
+++ b/lib/kolkrabbi-api.js
@@ -32,6 +32,13 @@ function createPipelineRepository (token, pipeline, repository) {
   })
 }
 
+function updatePipelineRepository (token, pipeline, body) {
+  return kolkrabbiRequest(`/pipelines/${pipeline}/repository`, token, {
+    method: 'PATCH',
+    body
+  })
+}
+
 function updateAppLink (token, app, body) {
   return kolkrabbiRequest(`/apps/${app}/github`, token, {
     method: 'PATCH',
@@ -41,4 +48,5 @@ function updateAppLink (token, app, body) {
 
 module.exports.getAccount = getAccount
 module.exports.createPipelineRepository = createPipelineRepository
+module.exports.updatePipelineRepository = updatePipelineRepository
 module.exports.updateAppLink = updateAppLink

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,10 +1,5 @@
-'use strict'
+const inquirer = require('inquirer')
 
 module.exports = function prompt (questions) {
-  let inquirer = require('inquirer')
-  return new Promise(function (resolve) {
-    inquirer.prompt(questions, function (answers) {
-      resolve(answers)
-    })
-  })
+  return inquirer.prompt(questions)
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "got": "^6.7.1",
     "heroku-cli-util": "6.0.11",
     "inflection": "1.8.0",
-    "inquirer": "0.12.0",
+    "inquirer": "2.0.0",
     "string-just": "0.0.2",
     "validator": "4.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "heroku-pipelines",
   "description": "pipelines heroku plugin",
   "version": "1.1.8",
-  "author": "Mark Pundsack @markpundsack",
+  "author": "Heroku Developer Experience team",
   "repository": "heroku/heroku-pipelines",
   "bugs": {
     "url": "https://github.com/heroku/heroku-pipelines/issues"
@@ -23,6 +23,7 @@
   "dependencies": {
     "bluebird": "3.3.4",
     "co": "4.6.0",
+    "got": "^6.7.1",
     "heroku-cli-util": "6.0.11",
     "inflection": "1.8.0",
     "inquirer": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,13 @@
     "postversion": "npm publish && git push && git push --tags"
   },
   "standard": {
-    "globals": [ "describe", "context", "beforeEach", "afterEach", "it" ]
+    "globals": [
+      "describe",
+      "context",
+      "beforeEach",
+      "afterEach",
+      "it"
+    ]
   },
   "dependencies": {
     "bluebird": "3.3.4",
@@ -32,10 +38,12 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
+    "co-mocha": "^1.1.3",
     "mocha": "^2.2.5",
     "nock": "8.0.0",
     "nyc": "6.4.4",
     "sinon": "^1.15.3",
+    "sinon-as-promised": "^4.0.2",
     "sinon-chai": "^2.8.0",
     "standard": "^8.6.0"
   }

--- a/test/commands/pipelines/setup.js
+++ b/test/commands/pipelines/setup.js
@@ -1,0 +1,111 @@
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const sinon = require('sinon')
+const inquirer = require('inquirer')
+const expect = require('chai').expect
+const cmd = require('../../../commands/pipelines/setup')
+
+describe('pipelines:setup', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
+
+  it('errors if the user is not linked to GitHub', function * () {
+    try {
+      yield cmd.run({ args: {} })
+    } catch (error) {
+      expect(error.message).to.equal('Account not connected to GitHub.')
+    }
+  })
+
+  context('with an account connected to GitHub', function () {
+    let pipeline, repo, archiveURL, prodApp, stagingApp, kolkrabbiAccount
+    let api, kolkrabbi, github
+
+    beforeEach(function () {
+      archiveURL = 'https://example.com/archive.tar.gz'
+      kolkrabbiAccount = { github: { token: '123-abc' } }
+
+      pipeline = {
+        id: '123-pipeline',
+        name: 'my-pipeline'
+      }
+
+      repo = {
+        id: 123,
+        default_branch: 'master',
+        name: 'my-org/my-repo'
+      }
+
+      prodApp = {
+        id: '123-prod-app',
+        name: pipeline.name
+      }
+
+      stagingApp = {
+        id: '123-staging-app',
+        name: `${pipeline.name}-staging`
+      }
+
+      kolkrabbi = nock('https://kolkrabbi.heroku.com')
+      kolkrabbi.get('/account/github/token').reply(200, kolkrabbiAccount)
+      kolkrabbi.post(`/pipelines/${pipeline.id}/repository`).reply(201, {})
+      kolkrabbi.patch(`/apps/${stagingApp.id}/github`).reply(200, {})
+
+      github = nock('https://api.github.com')
+      github.get(`/repos/${repo.name}`).reply(200, repo)
+
+      github.get(`/repos/${repo.name}/tarball/${repo.default_branch}`).reply(301, '', {
+        location: archiveURL
+      })
+
+      api = nock('https://api.heroku.com')
+      api.post('/pipelines').reply(201, pipeline)
+
+      api.post('/app-setups', {
+        source_blob: { url: archiveURL },
+        app: { name: prodApp.name }
+      }).reply(201, { app: prodApp })
+
+      api.post('/app-setups', {
+        source_blob: { url: archiveURL },
+        app: { name: stagingApp.name }
+      }).reply(201, { app: stagingApp })
+
+      api.post('/pipeline-couplings', {
+        pipeline: pipeline.id,
+        app: prodApp.id,
+        stage: 'production'
+      }).reply(201, {})
+
+      api.post('/pipeline-couplings', {
+        pipeline: pipeline.id,
+        app: stagingApp.id,
+        stage: 'staging'
+      }).reply(201, {})
+
+      sinon.stub(inquirer, 'prompt').resolves({
+        name: pipeline.name,
+        repo: repo.name
+      })
+    })
+
+    afterEach(function () {
+      inquirer.prompt.restore()
+    })
+
+    it('runs', function* () {
+      yield cmd.run({ args: {} })
+
+      expect(cli.stdout).to.include(`heroku pipelines:open ${pipeline.id}`)
+
+      api.done()
+      github.done()
+      kolkrabbi.done()
+    })
+  })
+})

--- a/test/commands/pipelines/setup.js
+++ b/test/commands/pipelines/setup.js
@@ -8,10 +8,12 @@ const cmd = require('../../../commands/pipelines/setup')
 describe('pipelines:setup', function () {
   beforeEach(function () {
     cli.mockConsole()
+    sinon.stub(cli, 'open').returns(Promise.resolve())
   })
 
   afterEach(function () {
     nock.cleanAll()
+    cli.open.restore()
   })
 
   it('errors if the user is not linked to GitHub', function * () {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,6 @@
 --require ./test/init.js
+--require co-mocha
+--require sinon
+--require sinon-as-promised
 --recursive
 --reporter list


### PR DESCRIPTION
A single boostrap command allowing a new pipeline to be configured with sensible defaults:

```bash
❯ h pipelines:setup sausagess appleton/sausages -o heroku-devex
? Automatically deploy the master branch to staging? Yes
? Wait for CI to pass before deploying the master branch to staging? Yes
? Enable review apps? Yes
? Automatically create review apps for every PR? Yes
? Automatically destroy idle review apps after 5 days? Yes
? Enable automatic Heroku CI test runs? Yes
Creating pipeline... done
Linking to repo... done
Creating ⬢ sausagess (production app)... done
Creating ⬢ sausagess-staging (staging app)... done
Configuring pipeline... ⣻
Configuring pipeline... done
View your new pipeline by running `heroku pipelines:open 073d2f38-96df-4709-9a6d-eb9a55360921`
```