### PR TITLE
Add codecov coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Pipelines Plugin for Heroku Toolbelt
 
+[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
+
 [![npm
 version](https://img.shields.io/npm/v/heroku-pipelines.svg)](https://www.npmjs.com/package/heroku-pipelines)
 [![build status](https://img.shields.io/circleci/project/heroku/heroku-pipelines.svg)](https://circleci.com/gh/heroku/heroku-pipelines)
+[![codecov](https://codecov.io/gh/heroku/heroku-pipelines/branch/master/graph/badge.svg)](https://codecov.io/gh/heroku/heroku-pipelines)
 
 A Heroku CLI plugin for [continuous delivery](https://www.heroku.com/continuous-delivery) on Heroku.
 
@@ -10,129 +13,34 @@ This plugin is used to set up a collection of apps sharing a common codebase whe
 
 ## How to install this plugin
 
-This plugin is installed by default with the 
-[Heroku Toolbelt](https://toolbelt.heroku.com/). You do not need to install it 
+This plugin is installed by default with the
+[Heroku Toolbelt](https://toolbelt.heroku.com/). You do not need to install it
 yourself. Just update your Toolbelt and plugins:
 
 ```
 $ heroku update
 ```
 
-### [Using Pipelines](https://devcenter.heroku.com/articles/pipelines)
+## Using Pipelines
 
-#### Create a pipeline
+https://devcenter.heroku.com/articles/pipelines
 
-```bash
-$ heroku pipelines:create -a example # NAME and -s STAGE are optional and implied from app name
-? Pipeline name: example
-? Stage of example: production
-Creating example pipeline... done
-Adding example to example pipeline as production... done
+## Development
+
+First, please read [Developing CLI Plugins on Heroku's DevCenter](https://devcenter.heroku.com/articles/developing-toolbelt-plug-ins).
+
+#### Run Tests
+
+```
+$ npm test
 ```
 
-#### Add apps to a pipeline
+#### Deploy
 
-```bash
-$ heroku pipelines:add example -a example-admin -s production
-Adding example-admin to example pipeline as production... done
+1. Release a new version of this npm package.
 
-$ heroku pipelines:add -a example-staging example
-? Stage of example-staging: staging
-Adding example-staging to example pipeline as staging... done
-```
+  ```
+  $ npm version patch/minor/major
+  ```
 
-#### List pipelines
-
-```bash
-$ heroku pipelines:list # Repo isn't yet returned
-example github:heroku/example
-sushi   github:heroku/sushi
-```
-
-#### Show pipeline detail
-
-```bash
-$ heroku pipelines:info example # Source and Flow aren't returned yet
-=== example
-Source type: github
-Source repo: heroku/example
-Staging:     example-staging
-Production:  example
-             example-admin
-Flow:        example-staging --> example, example-admin
-```
-
-#### Diff an app in a pipeline
-
-```bash
-$ heroku pipelines:diff -a my-app-staging
-Fetching apps from pipeline... done
-Fetching release info for all apps... done
-
-my-app-staging is up to date with my-app
-```
-
-#### Promote an app in a pipeline
-
-```bash
-$ heroku pipelines:promote -r staging
-Fetching app info... done
-Fetching apps from my-pipeline... done
-Starting promotion to production... done
-Waiting for promotion to complete... done
-
-Promotion successful
-My-App:    succeeded
-My-App-Eu: succeeded
-```
-
-#### Promote to specified apps in a pipeline
-```bash
-$ heroku pipelines:promote -a example-staging --to my-production-app1,my-production-app2
-Starting promotion to apps: my-production-app1,my-production-app2... done
-Waiting for promotion to complete... done
-Promotion successful
-my-production-app1: succeeded
-my-production-app2: succeeded
-```
-
-#### Update apps in a pipeline
-
-```bash
-$ heroku pipelines:update -s staging -a example-admin
-Changing example-admin to staging... done
-```
-
-#### Remove app from a pipeline
-
-```bash
-$ heroku pipelines:remove -a example-admin
-Removing example-admin... done
-```
-
-#### Rename pipeline
-
-```bash
-$ heroku pipelines:rename example www
-Renaming example pipeline to www... done
-```
-
-#### Destroy pipeline
-
-```bash
-$ heroku pipelines:destroy www
-Destroying www pipeline... done
-```
-
-#### Open a pipeline in Dashboard
-
-```bash
-$ heroku pipelines:open example
-Opening dashboard... done
-```
-
-### TODO
-
-* `heroku pipelines:status [-a APP | -r REMOTE]`
-* `heroku pipelines:list` with repo
-* `heroku pipelines:info` with full information
+2. Open a new pr in https://github.com/heroku/cli/blob/master/package.json, updating to the appropriate heroku-pipelines version.

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,11 @@
 machine:
   node:
     version: 6.2.0
+test:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/mocha
+  override:
+    - MOCHA_FILE=$CIRCLE_TEST_REPORTS/mocha/results.xml nyc mocha test -R mocha-junit-reporter
+    - standard
+  post:
+    - nyc report --reporter=text-lcov > coverage.lcov && bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chai": "^3.0.0",
     "co-mocha": "^1.1.3",
     "mocha": "^2.2.5",
+    "mocha-junit-reporter": "1.12.0",
     "nock": "8.0.0",
     "nyc": "6.4.4",
     "sinon": "^1.15.3",


### PR DESCRIPTION
Also it uses Heroku DevCenter docs exclusively for reference, so we don't have to maintain the same information in both places both in the README and https://devcenter.heroku.com/articles/pipelines. 