### PR TITLE
Show errors during app creation for pipeline:setup

### DIFF
--- a/commands/pipelines/setup.js
+++ b/commands/pipelines/setup.js
@@ -329,6 +329,5 @@ module.exports = {
       setupPipeline(kolkrabbi, stagingApp.id, settings, pipeline.id, ciSettings)
     )
     yield cli.open(`https://dashboard.heroku.com/pipelines/${pipeline.id}`)
-    cli.exit(1)
   }))
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,37 +4,19 @@ const V3_HEADER = 'application/vnd.heroku+json; version=3'
 const FILTERS_HEADER = V3_HEADER + '.filters'
 
 function getCoupling (heroku, app) {
-  return heroku.request({
-    method: 'GET',
-    path: `/apps/${app}/pipeline-couplings`,
-    headers: { 'Accept': V3_HEADER }
-  })
+  return heroku.get(`/apps/${app}/pipeline-couplings`)
 }
 
 function postCoupling (heroku, pipeline, app, stage) {
-  return heroku.request({
-    method: 'POST',
-    path: '/pipeline-couplings',
-    body: {app: app, pipeline: pipeline, stage: stage},
-    headers: { 'Accept': V3_HEADER }
-  })
+  return heroku.request('/pipeline-couplings', { body: {app: app, pipeline: pipeline, stage: stage} })
 }
 
 function patchCoupling (heroku, id, stage) {
-  return heroku.request({
-    method: 'PATCH',
-    path: `/pipeline-couplings/${id}`,
-    body: {stage: stage},
-    headers: { 'Accept': V3_HEADER }
-  })
+  return heroku.patch(`/pipeline-couplings/${id}`, { body: {stage: stage} })
 }
 
 function deleteCoupling (heroku, id) {
-  return heroku.request({
-    method: 'DELETE',
-    path: `/pipeline-couplings/${id}`,
-    headers: { 'Accept': V3_HEADER }
-  })
+  return heroku.delete(`/pipeline-couplings/${id}`)
 }
 
 function createCoupling (heroku, pipeline, app, stage) {
@@ -52,44 +34,23 @@ function removeCoupling (heroku, app) {
 }
 
 function listCouplings (heroku, pipelineId) {
-  return heroku.request({
-    method: 'GET',
-    path: `/pipelines/${pipelineId}/pipeline-couplings`,
-    headers: { 'Accept': V3_HEADER }
-  })
+  return heroku.get(`/pipelines/${pipelineId}/pipeline-couplings`)
 }
 
 function getPipeline (heroku, id) {
-  return heroku.request({
-    method: 'GET',
-    path: `/pipelines/${id}`,
-    headers: { Accept: V3_HEADER }
-  })
+  return heroku.get(`/pipelines/${id}`)
 }
 
 function findPipelineByName (heroku, idOrnName) {
-  return heroku.request({
-    method: 'GET',
-    path: `/pipelines?eq[name]=${idOrnName}`
-  })
+  return heroku.get(`/pipelines?eq[name]=${idOrnName}`)
 }
 
 function createPipeline (heroku, name) {
-  return heroku.request({
-    method: 'POST',
-    path: '/pipelines',
-    headers: { 'Accept': V3_HEADER },
-    body: { name }
-  })
+  return heroku.post('/pipelines', { body: { name } })
 }
 
 function createAppSetup (heroku, body) {
-  return heroku.request({
-    method: 'POST',
-    path: '/app-setups',
-    headers: { 'Accept': V3_HEADER },
-    body
-  })
+  return heroku.post('/app-setups', { body })
 }
 
 function getAppFilter (heroku, appIds) {
@@ -115,33 +76,29 @@ function listPipelineApps (heroku, pipelineId) {
 }
 
 function getAccountFeature (heroku, feature) {
-  return heroku.request({
-    method: 'GET',
-    path: `/account/features/${feature}`,
-    headers: { Accept: V3_HEADER }
-  })
+  return heroku.get(`/account/features/${feature}`)
 }
 
-exports.getCoupling = getCoupling
-exports.postCoupling = postCoupling
-exports.patchCoupling = patchCoupling
-exports.deleteCoupling = deleteCoupling
+function getAppSetup (heroku, buildId) {
+  return heroku.get(`/app-setups/${buildId}`)
+}
 
-exports.createCoupling = createCoupling
-exports.updateCoupling = updateCoupling
-exports.removeCoupling = removeCoupling
-exports.listCouplings = listCouplings
-
-exports.getPipeline = getPipeline
-exports.findPipelineByName = findPipelineByName
-exports.createPipeline = createPipeline
-
-exports.createAppSetup = createAppSetup
-
-exports.getAppFilter = getAppFilter
-
-exports.listPipelineApps = listPipelineApps
-
-exports.getAccountFeature = getAccountFeature
-
-exports.V3_HEADER = V3_HEADER
+module.exports = {
+  createAppSetup,
+  createCoupling,
+  createPipeline,
+  deleteCoupling,
+  getAccountFeature,
+  getAppFilter,
+  getAppSetup,
+  getCoupling,
+  getPipeline,
+  findPipelineByName,
+  listCouplings,
+  listPipelineApps,
+  patchCoupling,
+  postCoupling,
+  removeCoupling,
+  updateCoupling,
+  V3_HEADER
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -8,11 +8,13 @@ function getCoupling (heroku, app) {
 }
 
 function postCoupling (heroku, pipeline, app, stage) {
-  return heroku.post('/pipeline-couplings', { body: {app: app, pipeline: pipeline, stage: stage} })
+  return heroku.post('/pipeline-couplings', {
+    body: { app, pipeline, stage }
+  })
 }
 
 function patchCoupling (heroku, id, stage) {
-  return heroku.patch(`/pipeline-couplings/${id}`, { body: {stage: stage} })
+  return heroku.patch(`/pipeline-couplings/${id}`, { body: { stage } })
 }
 
 function deleteCoupling (heroku, id) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -8,7 +8,7 @@ function getCoupling (heroku, app) {
 }
 
 function postCoupling (heroku, pipeline, app, stage) {
-  return heroku.request('/pipeline-couplings', { body: {app: app, pipeline: pipeline, stage: stage} })
+  return heroku.post('/pipeline-couplings', { body: {app: app, pipeline: pipeline, stage: stage} })
 }
 
 function patchCoupling (heroku, id, stage) {

--- a/test/commands/pipelines/setup.js
+++ b/test/commands/pipelines/setup.js
@@ -103,13 +103,16 @@ describe('pipelines:setup', function () {
             source_blob: { url: archiveURL },
             app: { name: prodApp.name, personal: true },
             pipeline_coupling: { stage: 'production', pipeline: pipeline.id }
-          }).reply(201, { app: prodApp })
+          }).reply(201, { id: 1, app: prodApp })
 
           api.post('/app-setups', {
             source_blob: { url: archiveURL },
             app: { name: stagingApp.name, personal: true },
             pipeline_coupling: { stage: 'staging', pipeline: pipeline.id }
-          }).reply(201, { app: stagingApp })
+          }).reply(201, { id: 2, app: stagingApp })
+
+          api.get('/app-setups/1').reply(200, { status: 'succeeded' })
+          api.get('/app-setups/2').reply(200, { status: 'succeeded' })
         })
 
         it('creates apps in the personal account', function* () {
@@ -165,13 +168,16 @@ describe('pipelines:setup', function () {
             source_blob: { url: archiveURL },
             app: { name: prodApp.name, organization },
             pipeline_coupling: { pipeline: pipeline.id, stage: 'production' }
-          }).reply(201, { app: prodApp })
+          }).reply(201, { id: 1, app: prodApp })
 
           api.post('/app-setups', {
             source_blob: { url: archiveURL },
             app: { name: stagingApp.name, organization },
             pipeline_coupling: { pipeline: pipeline.id, stage: 'staging' }
-          }).reply(201, { app: stagingApp })
+          }).reply(201, { id: 2, app: stagingApp })
+
+          api.get('/app-setups/1').reply(200, { status: 'succeeded' })
+          api.get('/app-setups/2').reply(200, { status: 'succeeded' })
         })
 
         it('creates apps in an organization', function* () {


### PR DESCRIPTION
For the command `pipeline:setup`, apps are created via the endpoint `POST /app-setup` in which a successful status response doesn't necessarily mean the apps were successfully created. These return `pending` and, in order to check out the status, it is necessarily to poll its status independently:

https://devcenter.heroku.com/articles/platform-api-reference#app-setup-info

Currently, the UX is is confusing since the pipeline setup carries on ending up with an empty pipeline page in dashboard if apps weren't successfully created (built).

This PR changes slightly the behavior to provide meaningful information in case something fails.

Demo:

**With an incorrect setup**:

![screen capture on 2017-03-06 at 17-17-47](https://cloud.githubusercontent.com/assets/306015/23637696/0db7dfa6-0292-11e7-9550-eaa0fe34ddca.gif)

**With a valid app.json**:

![screen capture on 2017-03-06 at 17-19-10](https://cloud.githubusercontent.com/assets/306015/23637688/04dd0e7e-0292-11e7-8236-87babd522292.gif)
