### PR TITLE
Only load *.js files from commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,7 @@ exports.topic = {
 var normalizedPath = path.join(__dirname, 'commands/pipelines')
 
 exports.commands = flatten(fs.readdirSync(normalizedPath).map(function (file) {
-  return require('./commands/pipelines/' + file)
-}))
+  if (file.endsWith('.js')) {
+    return require('./commands/pipelines/' + file)
+  }
+})).filter(function (e) { return e !== undefined })


### PR DESCRIPTION
IDEs which create swap files (such as vim) will prevent using this plugin linked, as it will try to load a non-js file.