### PR TITLE
Display the release command output if it is available

### DIFF
--- a/commands/pipelines/promote.js
+++ b/commands/pipelines/promote.js
@@ -132,12 +132,11 @@ function* streamReleaseCommand (heroku, targets, promotion) {
 
   cli.log('Running release command...')
   yield new Promise(function (resolve, reject) {
-    cli.got.stream(release.output_stream_url)
-      .on('error', reject)
-      .on('end', resolve)
-      .on('data', function (c) {
-        cli.log(c.toString('utf8'))
-      })
+    let stream = cli.got.stream(release.output_stream_url)
+    stream.on('error', reject)
+    stream.on('end', resolve)
+    let piped = stream.pipe(process.stdout)
+    piped.on('error', reject)
   })
 
   return yield pollPromotionStatus(heroku, promotion.id, false)

--- a/commands/pipelines/promote.js
+++ b/commands/pipelines/promote.js
@@ -30,14 +30,24 @@ function * getSecondFactor () {
   return secondFactor
 }
 
-function pollPromotionStatus (heroku, id) {
+function pollPromotionStatus (heroku, id, needsReleaseCommand) {
   return heroku.request({
     method: 'GET',
     path: `/pipeline-promotions/${id}/promotion-targets`
   }).then(function (targets) {
     if (targets.every(isComplete)) { return targets }
 
-    return BBPromise.delay(1000).then(pollPromotionStatus.bind(null, heroku, id))
+    //
+    // With only one target, we can return as soon as the release is created.
+    // The command will then read the release phase output
+    //
+    // `needsReleaseCommand` allows us to keep polling, as it can take a few
+    // seconds to get the release to succeeded after the release command
+    // finished.
+    //
+    if (needsReleaseCommand && targets.length === 1 && targets[0].release !== null) { return targets }
+
+    return BBPromise.delay(1000).then(pollPromotionStatus.bind(null, heroku, id, needsReleaseCommand))
   })
 }
 
@@ -102,6 +112,37 @@ function findAppInPipeline (apps, target) {
   return found
 }
 
+function* getRelease (heroku, app, release) {
+  return yield cli.action(`Fetching release info`, heroku.request({
+    method: 'GET',
+    path: `/apps/${app}/releases/${release}`
+  }))
+}
+
+function* streamReleaseCommand (heroku, targets, promotion) {
+  if (targets.length !== 1 || targets.every(isComplete)) {
+    return targets
+  }
+  const target = targets[0]
+  const release = yield getRelease(heroku, target.app.id, target.release.id)
+
+  if (!release.output_stream_url) {
+    return targets
+  }
+
+  cli.log('Running release command...')
+  yield new Promise(function (resolve, reject) {
+    cli.got.stream(release.output_stream_url)
+      .on('error', reject)
+      .on('end', resolve)
+      .on('data', function (c) {
+        cli.log(c.toString('utf8'))
+      })
+  })
+
+  return yield pollPromotionStatus(heroku, promotion.id, false)
+}
+
 module.exports = {
   topic: 'pipelines',
   command: 'promote',
@@ -156,8 +197,9 @@ module.exports = {
       heroku, promotionActionName, coupling.pipeline.id, coupling.app.id, targetApps
     )
 
-    const pollLoop = pollPromotionStatus(heroku, promotion.id)
-    const promotionTargets = yield cli.action('Waiting for promotion to complete', pollLoop)
+    const pollLoop = pollPromotionStatus(heroku, promotion.id, true)
+    let promotionTargets = yield cli.action('Waiting for promotion to complete', pollLoop)
+    promotionTargets = yield streamReleaseCommand(heroku, promotionTargets, promotion)
 
     const appsByID = keyBy(allApps, 'id')
 

--- a/commands/pipelines/promote.js
+++ b/commands/pipelines/promote.js
@@ -81,7 +81,7 @@ function* promote (heroku, label, id, sourceAppId, targetApps, secondFactor) {
   try {
     return yield cli.action(label, heroku.request(options))
   } catch (error) {
-    if (error.body.id !== 'two_factor') {
+    if (!error.body || error.body.id !== 'two_factor') {
       throw error
     }
     const secondFactor = yield getSecondFactor()

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "sinon": "^1.15.3",
     "sinon-as-promised": "^4.0.2",
     "sinon-chai": "^2.8.0",
-    "standard": "^8.6.0"
+    "standard": "^8.6.0",
+    "std-mocks": "1.0.1"
   },
   "keywords": [
     "heroku-plugin"

--- a/test/commands/pipelines/promote.js
+++ b/test/commands/pipelines/promote.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect
 const cli = require('heroku-cli-util')
 const nock = require('nock')
 const cmd = require('../../../commands/pipelines/promote')
+const stdMocks = require('std-mocks')
 
 describe('pipelines:promote', function () {
   const api = 'https://api.heroku.com'
@@ -193,6 +194,7 @@ describe('pipelines:promote', function () {
     }
 
     it('streams the release command output', function () {
+      stdMocks.use()
       mockPromotionTargetsWithRelease(targetReleaseWithOutput)
 
       return cmd.run({ app: sourceApp.name }).then(function () {
@@ -201,6 +203,8 @@ describe('pipelines:promote', function () {
         expect(cli.stdout).to.contain('Release Command Output')
         expect(cli.stdout).to.contain('successful')
       })
+        .then(() => stdMocks.restore())
+        .catch(() => stdMocks.restore())
     })
   })
 })


### PR DESCRIPTION
In the case of a promotion with a single target, we will fetch the release, look for `output_stream_url` and, if it is present, stream the data it returns.

@heroku/devex this is to start discussion. You might have a better implementation.

cc @heroku/build 