### PR TITLE
Keep polling if there's no release phase output

### DIFF
--- a/commands/pipelines/promote.js
+++ b/commands/pipelines/promote.js
@@ -121,13 +121,13 @@ function* getRelease (heroku, app, release) {
 
 function* streamReleaseCommand (heroku, targets, promotion) {
   if (targets.length !== 1 || targets.every(isComplete)) {
-    return targets
+    return yield pollPromotionStatus(heroku, promotion.id, false)
   }
   const target = targets[0]
   const release = yield getRelease(heroku, target.app.id, target.release.id)
 
   if (!release.output_stream_url) {
-    return targets
+    return yield pollPromotionStatus(heroku, promotion.id, false)
   }
 
   cli.log('Running release command...')

--- a/test/commands/pipelines/promote.js
+++ b/test/commands/pipelines/promote.js
@@ -68,7 +68,7 @@ describe('pipelines:promote', function () {
     let pollCount = 0
     return nock(api)
       .get(`/pipeline-promotions/${promotion.id}/promotion-targets`)
-      .twice()
+      .thrice()
       .reply(200, function () {
         pollCount++
 


### PR DESCRIPTION
If api doesn't return a release phase output, we need to keep polling until the promotion status is succeeded, not return the targets right away.