### PR TITLE
Export disambiguatePipeline function

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,3 +15,5 @@ exports.commands = flatten(fs.readdirSync(normalizedPath).map(function (file) {
     return require('./commands/pipelines/' + file)
   }
 })).filter(function (e) { return e !== undefined })
+
+exports.disambiguatePipeline = require('./lib/disambiguate')


### PR DESCRIPTION
This will be useful to disambiguate pipelines in other CLI clients.

Tested in `heroku-ci` (in this [PR](https://github.com/heroku/heroku-ci/pull/33)), and it works just doing:

```js
const disambiguatePipeline = require('heroku-pipelines').disambiguatePipeline
// ....
pipeline = yield disambiguatePipeline(client, pipeline)
```
