### PR TITLE
Only pass user-agent if it is present

### DIFF
--- a/commands/pipelines/diff.js
+++ b/commands/pipelines/diff.js
@@ -81,11 +81,12 @@ function* diff (targetApp, downstreamApp, githubToken, herokuUserAgent) {
   // Do the actual Github diff
   try {
     const path = `${targetApp.repo}/compare/${downstreamApp.hash}...${targetApp.hash}`
+    const headers = { authorization: 'token ' + githubToken }
+
+    if (herokuUserAgent) headers['user-agent'] = herokuUserAgent
+
     const res = yield cli.got.get(`https://api.github.com/repos/${path}`, {
-      headers: {
-        authorization: 'token ' + githubToken,
-        'user-agent': herokuUserAgent
-      },
+      headers,
       json: true
     })
     cli.log('')


### PR DESCRIPTION
For some reason the CLI has stopped providing a `heroku.options.userAgent`. I'm not sure if that was ever part of the API but I've [opened an issue](https://github.com/heroku/cli/issues/479).

Passing undefined into got.get causes an error to throw which we'd be better off ignoring.