### PR TITLE
Update help output for pipelines:info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Update help output of `pipelines:info`
+
 ## [2.2.0] 2017-09-06
 
 - Show pipeline owner when it has one set in the command `pipelines:info`

--- a/commands/pipelines/info.js
+++ b/commands/pipelines/info.js
@@ -26,11 +26,18 @@ module.exports = {
   description: 'show list of apps in a pipeline',
   help: `Example:
 
-    $ heroku pipelines:info example
-    === example
-    Staging:     example-staging
-    Production:  example
-    example-admin`,
+  $ heroku pipelines:info example
+  name:  example
+  owner: my-team (team)
+
+  app name                     stage
+  ───────────────────────────  ──────────
+  ⬢ example-pr-16              review
+  ⬢ example-pr-19              review
+  ⬢ example-pr-23              review
+  ⬢ example-staging            staging
+  ⬢ example-staging-2          staging
+  ⬢ example-production         production`,
   needsAuth: true,
   args: [
     {name: 'pipeline', description: 'pipeline to show', optional: false}


### PR DESCRIPTION
This is automatically shown in this Dev Center article: https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-pipelines-info-pipeline.

Forgot to do this in #67 