### PR TITLE
Show mixed ownership warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Update help output of `pipelines:info`
+- Show warning when operating in an owned pipeline with apps with different owners with the `pipelines:info` command.
 
 ## [2.2.0] 2017-09-06
 

--- a/lib/ownership.js
+++ b/lib/ownership.js
@@ -1,0 +1,44 @@
+const cli = require('heroku-cli-util')
+const getTeam = require('./api').getTeam
+const Promise = require('bluebird')
+
+function warnMixedOwnership (pipelineApps, pipeline, owner) {
+  const hasMixedOwnership = pipelineApps.some((app) => {
+    return app.owner.id !== pipeline.owner.id
+  })
+
+  if (hasMixedOwnership) {
+    cli.log()
+    let message = `Some apps in this pipeline do not belong to ${cli.color.cmd(owner)}.`
+    message += `\n\nAll apps in a pipeline must have the same owner as the pipeline owner.`
+    message += `\nTransfer these apps or change the pipeline owner in pipeline settings.`
+    message += `\nSee ${cli.color.cyan('https://devcenter.heroku.com/articles/pipeline-ownership-transition')} for more info.`
+    cli.warn(message)
+  }
+}
+
+function getOwner (heroku, apps, pipeline) {
+  let owner, ownerPromise
+
+  if (pipeline.owner.type === 'team') {
+    ownerPromise = getTeam(heroku, pipeline.owner.id)
+  } else {
+    const app = apps.find((app) => {
+      return app.owner.id === pipeline.owner.id
+    })
+
+    // If pipeline owner doesn't own any application and type is user (unlikely)
+    // We return the uuid as default
+    owner = app ? app.owner.email : pipeline.owner.id
+    ownerPromise = Promise.resolve(owner)
+  }
+
+  return ownerPromise.then((owner) => {
+    return owner.name ? `${owner.name} (team)` : owner
+  })
+}
+
+module.exports = {
+  getOwner,
+  warnMixedOwnership
+}


### PR DESCRIPTION
## Checklist

The checklist enumerates the tasks you set out to do before the PR becomes ready for review

- [x] Implement feature
- [x] Write tests
- [x] Update [CHANGELOG.md](https://github.com/heroku/heroku-pipelines/blob/master/CHANGELOG.md)

## Why

We want to encourage users to set a single ownership model in their pipelines. The metrics around this command proved that it was worth adding a warning message advising them about this situation when proceeds.

This warning is only added to the `pipelines:info` command as it'd be API expensive to check pipeline coupling ownership in other commands which would slow down the experience considerably. 

## What are the acceptance criteria for the change?

- [ ] [DevEx](https://github.com/heroku/devex) gives a :+1:

## How can the change be tested

- Download this code
- Run it locally doing `heroku plugins:link .`
- Run `heroku pipelines:info` in a pipeline you think it's suspicious of being in this situation.

- enumerate a *list* of steps that the reviewer may step through to fully experience the changeset being introduced

## Demonstration


```
› heroku pipelines:info my-mixed-pipeline
name:  my-mixed-pipeline
owner: my-team (team)

app name          stage
──────────────    ───────
⬢ one-app         staging
⬢ another-app     staging

 ▸    Some apps in this pipeline do not belong to my-team (team).
 ▸
 ▸    All apps in a pipeline must have the same owner as the pipeline owner.
 ▸    Transfer these apps or change the pipeline owner in pipeline settings.
 ▸    See https://devcenter.heroku.com/articles/pipeline-ownership-transition for more info.
 ```

## Who's Affected

Users with apps in a pipeline owned by different users/teams.

## Blockers & upstream dependencies

None.