### PR TITLE
Fix serialization for pipelines:info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fixes serialization for `pipelines:info --json`. https://github.com/heroku/heroku-pipelines/pull/72 changed the serialization for that command changing `apps` to `pipelineApps`.
+
 ## [2.3.0] 2017-09-12
 
 - Update help output of `pipelines:info`

--- a/commands/pipelines/info.js
+++ b/commands/pipelines/info.js
@@ -39,7 +39,7 @@ module.exports = {
     let owner
 
     if (context.flags.json) {
-      cli.styledJSON({pipeline, pipelineApps})
+      cli.styledJSON({pipeline, apps: pipelineApps})
     } else {
       cli.log(`name:  ${pipeline.name}`)
 


### PR DESCRIPTION
Fixes serialization for `pipelines:info --json`. https://github.com/heroku/heroku-pipelines/pull/72 changed the serialization for that command changing `apps` to `pipelineApps`.