### PR TITLE
Implement heroku pipelines:transfer command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add `pipelines:transfer` command to set and update the pipeline owner.
+
 ## [2.3.1] 2017-09-13
 
 - Fixes serialization for `pipelines:info --json`. https://github.com/heroku/heroku-pipelines/pull/72 changed the serialization for that command changing `apps` to `pipelineApps`.

--- a/commands/pipelines/transfer.js
+++ b/commands/pipelines/transfer.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const co = require('co')
+const cli = require('heroku-cli-util')
+const disambiguate = require('../../lib/disambiguate')
+const api = require('../../lib/api')
+const { flags } = require('cli-engine-heroku')
+
+function * getTeamOwner (heroku, name) {
+  const team = yield api.getTeam(heroku, name)
+  return { id: team.id, type: 'team' }
+}
+
+function * getAccountOwner (heroku, name) {
+  const account = yield api.getAccountInfo(heroku, name)
+  return { id: account.id, type: 'user' }
+}
+
+function * getOwner (heroku, name) {
+  try {
+    return yield getTeamOwner(heroku, name)
+  } catch (e) {}
+
+  try {
+    return yield getAccountOwner(heroku, name)
+  } catch (e) {
+    throw new Error(`Cannot find a team or account for "${name}"`)
+  }
+}
+
+module.exports = {
+  topic: 'pipelines',
+  command: 'transfer',
+  description: 'transfer ownership of a pipeline',
+  help: `Example:
+
+    $ heroku pipelines:transfer me@example.com -p example
+    Transferring example pipeline to the me@example.com account... done
+
+    $ heroku pipelines:transfer acme-widgets -p example
+    Transferring example pipeline to the acme-widgets team... done`,
+  needsApp: false,
+  needsAuth: true,
+  args: [
+    {name: 'owner', description: 'the owner to transfer the pipeline to', optional: false}
+  ],
+  flags: [
+    flags.pipeline({ name: 'pipeline', required: true, hasValue: true })
+  ],
+  run: cli.command(co.wrap(function* (context, heroku) {
+    const pipeline = yield disambiguate(heroku, context.flags.pipeline)
+    const newOwner = yield getOwner(heroku, context.args.owner)
+
+    const promise = heroku.request({
+      method: 'PATCH',
+      path: `/pipelines/${pipeline.id}`,
+      body: { owner: newOwner },
+      headers: {'Accept': 'application/vnd.heroku+json; version=3.pipelines'}
+    })
+
+    let displayType = { team: 'team', user: 'account' }[newOwner.type]
+
+    yield cli.action(
+      `Transferring ${cli.color.pipeline(pipeline.name)} pipeline to the ${context.args.owner} ${displayType}`,
+      promise
+    )
+  }))
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -58,8 +58,8 @@ function getAppFilter (heroku, appIds) {
   })
 }
 
-function getAccountInfo (heroku) {
-  return heroku.get('/account')
+function getAccountInfo (heroku, id = '~') {
+  return heroku.get(`/users/${id}`)
 }
 
 function getAccountFeature (heroku, feature) {

--- a/test/commands/pipelines/create.js
+++ b/test/commands/pipelines/create.js
@@ -21,7 +21,7 @@ describe('pipelines:create', function () {
       pipeline = {name: 'example', id: '0123', owner: { id: '1234-567', type: 'user' }}
 
       heroku
-      .get('/account')
+      .get('/users/~')
       .reply(200, { id: '1234-567' })
       .post('/pipelines')
       .reply(201, pipeline)

--- a/test/commands/pipelines/setup.js
+++ b/test/commands/pipelines/setup.js
@@ -114,7 +114,7 @@ describe('pipelines:setup', function () {
           api.get('/app-setups/1').reply(200, { status: 'succeeded' })
           api.get('/app-setups/2').reply(200, { status: 'succeeded' })
 
-          api.get('/account').reply(200, { id: '1234-567' })
+          api.get('/users/~').reply(200, { id: '1234-567' })
         })
 
         it('creates apps in the personal account', function* () {

--- a/test/commands/pipelines/transfer.js
+++ b/test/commands/pipelines/transfer.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const cmd = require('../../../commands/pipelines/transfer')
+const assert = require('assert')
+
+describe('pipelines:transfer', function () {
+  beforeEach(() => cli.mockConsole())
+  let api, pipeline, team, account
+
+  beforeEach(function () {
+    pipeline = {
+      id: 'd214bea8-aaa0-4f98-91ba-e781cb26d50f',
+      name: 'test-pipeline'
+    }
+
+    team = {
+      id: 'caee7555-c3ba-4959-a393-a0ae93bb958f',
+      name: 'foo-team'
+    }
+
+    account = {
+      id: 'bcf91aa0-9465-4ad8-a38f-983cd177780f',
+      email: 'user@example.com'
+    }
+
+    api = nock(`https://api.heroku.com`)
+    api.get(`/pipelines/${pipeline.id}`).reply(200, pipeline)
+  })
+
+  it('transfers to a team', function () {
+    api.get(`/teams/${team.name}`).reply(200, team)
+    const update = api.patch(`/pipelines/${pipeline.id}`, {
+      owner: { id: team.id, type: 'team' }
+    }).reply(200, {})
+
+    return cmd.run({
+      flags: { pipeline: pipeline.id },
+      args: { owner: team.name }
+    }).then(() => {
+      const output = cli.stderr
+      output.should.contain(
+        `Transferring ${pipeline.name} pipeline to the ${team.name} team... done`
+      )
+      assert.ok(update.isDone(), 'Pipeline should be updated')
+    })
+  })
+
+  it('transfers to an account', function () {
+    api.get(`/users/${account.email}`).reply(200, account)
+    const update = api.patch(`/pipelines/${pipeline.id}`, {
+      owner: { id: account.id, type: 'user' }
+    }).reply(200, {})
+
+    return cmd.run({
+      flags: { pipeline: pipeline.id },
+      args: { owner: account.email }
+    }).then(() => {
+      const output = cli.stderr
+      output.should.contain(
+        `Transferring ${pipeline.name} pipeline to the ${account.email} account... done`
+      )
+      assert.ok(update.isDone(), 'Pipeline should be updated')
+    })
+  })
+})


### PR DESCRIPTION
## Checklist

- [x] Add `heroku pipelines:transfer` to a team.
- [x] Add `heroku pipelines:transfer` to an account.
- [x] Tests for both cases

## Why
To support pipelines ownership

## What are the acceptance criteria for the change?
- [ ] [DevEx](https://github.com/heroku/devex) gives a :+1:

## How can the change be tested
- `heroku pipelines:transfer $PIPELINE_NAME $TEAM_NAME`
- `heroku pipelines:transfer $PIPELINE_NAME $ACCOUNT_EMAIL`

## Demonstration
```
    $ heroku pipelines:transfer example me@example.com
    Transferring example pipeline to the me@example.com account... done

    $ heroku pipelines:transfer example acme-widgets
    Transferring example pipeline to the acme-widgets team... done
```

## Who's Affected
All users of the plugin

## Blockers & upstream dependencies
None