### PR TITLE
Update transfer to new endpoint

### DIFF
--- a/commands/pipelines/info.js
+++ b/commands/pipelines/info.js
@@ -3,9 +3,8 @@
 const co = require('co')
 const cli = require('heroku-cli-util')
 const disambiguate = require('../../lib/disambiguate')
+const renderPipeline = require('../../lib/render-pipeline')
 const listPipelineApps = require('../../lib/api').listPipelineApps
-const sortBy = require('lodash.sortby')
-const PipelineOwner = require('../../lib/ownership')
 
 module.exports = {
   topic: 'pipelines',
@@ -36,41 +35,14 @@ module.exports = {
   run: cli.command(co.wrap(function* (context, heroku) {
     const pipeline = yield disambiguate(heroku, context.args.pipeline)
     const pipelineApps = yield listPipelineApps(heroku, pipeline.id)
-    let owner
 
     if (context.flags.json) {
       cli.styledJSON({pipeline, apps: pipelineApps})
     } else {
-      cli.log(`name:  ${pipeline.name}`)
-
-      if (pipeline.owner) {
-        owner = yield PipelineOwner.getOwner(heroku, pipelineApps, pipeline)
-        cli.log(`owner: ${owner}`)
-      }
-      cli.log('')
-
-      let columns = [
-        {key: 'name', label: 'app name', format: (n) => cli.color.app(n)},
-        {key: 'coupling.stage', label: 'stage'}
-      ]
-
-      if (context.flags['with-owners']) {
-        columns.push({
-          key: 'owner.email', label: 'owner', format: (e) => e.endsWith('@herokumanager.com') ? `${e.split('@')[0]} (team)` : e
-        })
-      }
-
-      const developmentApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'development'), ['name'])
-      const reviewApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'review'), ['name'])
-      const stagingApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'staging'), ['name'])
-      const productionApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'production'), ['name'])
-      const apps = developmentApps.concat(reviewApps).concat(stagingApps).concat(productionApps)
-
-      cli.table(apps, { columns })
-
-      if (pipeline.owner) {
-        PipelineOwner.warnMixedOwnership(pipelineApps, pipeline, owner)
-      }
+      yield renderPipeline(heroku, pipeline, pipelineApps, {
+        withOwners: context.flags['with-owners'],
+        showOwnerWarning: true
+      })
     }
   }))
 }

--- a/commands/pipelines/info.js
+++ b/commands/pipelines/info.js
@@ -13,7 +13,7 @@ module.exports = {
   help: `Example:
 
   $ heroku pipelines:info example
-  name:  example
+  === example
   owner: my-team (team)
 
   app name                     stage

--- a/commands/pipelines/transfer.js
+++ b/commands/pipelines/transfer.js
@@ -4,6 +4,7 @@ const co = require('co')
 const cli = require('heroku-cli-util')
 const disambiguate = require('../../lib/disambiguate')
 const api = require('../../lib/api')
+const renderPipeline = require('../../lib/render-pipeline')
 const { flags } = require('cli-engine-heroku')
 
 function * getTeamOwner (heroku, name) {
@@ -45,20 +46,35 @@ module.exports = {
     {name: 'owner', description: 'the owner to transfer the pipeline to', optional: false}
   ],
   flags: [
-    flags.pipeline({ name: 'pipeline', required: true, hasValue: true })
+    flags.pipeline({ name: 'pipeline', required: true, hasValue: true }),
+    { name: 'confirm', char: 'c', hasValue: true }
   ],
   run: cli.command(co.wrap(function* (context, heroku) {
     const pipeline = yield disambiguate(heroku, context.flags.pipeline)
     const newOwner = yield getOwner(heroku, context.args.owner)
+    const apps = yield api.listPipelineApps(heroku, pipeline.id)
+    const displayType = { team: 'team', user: 'account' }[newOwner.type]
+    let confirmName = context.flags.confirm
+
+    if (!confirmName) {
+      yield renderPipeline(heroku, pipeline, apps)
+      cli.log('')
+      cli.warn(`This will transfer ${cli.color.pipeline(pipeline.name)} and all of the listed apps to the ${context.args.owner} ${displayType}`)
+      cli.warn(`to proceed, type ${cli.color.red(pipeline.name)} or re-run this command with ${cli.color.red('--confirm')} ${pipeline.name}`)
+      confirmName = yield cli.prompt('', {})
+    }
+
+    if (confirmName !== pipeline.name) {
+      cli.warn(`Confirmation did not match ${cli.color.red(pipeline.name)}. Aborted.`)
+      return
+    }
 
     const promise = heroku.request({
-      method: 'PATCH',
-      path: `/pipelines/${pipeline.id}`,
-      body: { owner: newOwner },
+      method: 'POST',
+      path: '/pipeline-transfers',
+      body: { pipeline: { id: pipeline.id }, new_owner: newOwner },
       headers: {'Accept': 'application/vnd.heroku+json; version=3.pipelines'}
     })
-
-    let displayType = { team: 'team', user: 'account' }[newOwner.type]
 
     yield cli.action(
       `Transferring ${cli.color.pipeline(pipeline.name)} pipeline to the ${context.args.owner} ${displayType}`,

--- a/commands/pipelines/transfer.js
+++ b/commands/pipelines/transfer.js
@@ -36,9 +36,32 @@ module.exports = {
   help: `Example:
 
     $ heroku pipelines:transfer me@example.com -p example
+    === example
+
+    app name              stage
+    ────────────────────  ───────────
+    ⬢ example-dev         development
+    ⬢ example-staging     staging
+    ⬢ example-prod        production
+
+     ▸    This will transfer example and all of the listed apps to the me@example.com account
+     ▸    to proceed, type edamame or re-run this command with --confirm example
+    > example
     Transferring example pipeline to the me@example.com account... done
 
     $ heroku pipelines:transfer acme-widgets -p example
+    === example
+
+    app name              stage
+    ────────────────────  ───────────
+    ⬢ example-dev         development
+    ⬢ example-staging     staging
+    ⬢ example-prod        production
+
+     ▸    This will transfer example and all of the listed apps to the acme-widgets team
+     ▸    to proceed, type edamame or re-run this command with --confirm example
+    > example
+
     Transferring example pipeline to the acme-widgets team... done`,
   needsApp: false,
   needsAuth: true,

--- a/lib/render-pipeline.js
+++ b/lib/render-pipeline.js
@@ -1,0 +1,39 @@
+const cli = require('heroku-cli-util')
+const sortBy = require('lodash.sortby')
+const PipelineOwner = require('./ownership')
+
+function * renderPipeline (heroku, pipeline, pipelineApps, { withOwners, showOwnerWarning } = { withOwners: false, showOwnerWarning: false }) {
+  cli.styledHeader(pipeline.name)
+
+  let owner
+  if (pipeline.owner) {
+    owner = yield PipelineOwner.getOwner(heroku, pipelineApps, pipeline)
+    cli.log(`owner: ${owner}`)
+  }
+  cli.log('')
+
+  let columns = [
+    {key: 'name', label: 'app name', format: (n) => cli.color.app(n)},
+    {key: 'coupling.stage', label: 'stage'}
+  ]
+
+  if (withOwners) {
+    columns.push({
+      key: 'owner.email', label: 'owner', format: (e) => e.endsWith('@herokumanager.com') ? `${e.split('@')[0]} (team)` : e
+    })
+  }
+
+  const developmentApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'development'), ['name'])
+  const reviewApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'review'), ['name'])
+  const stagingApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'staging'), ['name'])
+  const productionApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'production'), ['name'])
+  const apps = developmentApps.concat(reviewApps).concat(stagingApps).concat(productionApps)
+
+  cli.table(apps, { columns })
+
+  if (showOwnerWarning && pipeline.owner) {
+    PipelineOwner.warnMixedOwnership(pipelineApps, pipeline, owner)
+  }
+}
+
+module.exports = renderPipeline

--- a/test/commands/pipelines/info.js
+++ b/test/commands/pipelines/info.js
@@ -27,7 +27,7 @@ describe('pipelines:info', function () {
   function itShowsPipelineApps () {
     it('displays the pipeline info and apps', function () {
       return cmd.run({ args: { pipeline: 'example' }, flags: {} }).then(() => {
-        cli.stdout.should.contain('name:  example')
+        cli.stdout.should.contain('=== example')
         appNames.forEach((name) => {
           cli.stdout.should.contain(name)
         })


### PR DESCRIPTION
## Checklist
- [x] Extract a helper to render a pipeline with its apps
- [x] Update `pipelines:transfer` to use `POST /pipeline-transfers`
- [x] Add a warning to notify that the apps in the pipeline will also be transferred.
- [x] Add a confirmation step and a `--confirm` flag

## Why
For compatibility with the new endpoint.

## What are the acceptance criteria for the change?
- [ ] [DevEx](https://github.com/heroku/devex) gives a :+1:

## How can the change be tested
`herkou pipelines:transfer $NEW_OWNER p- $PIPELINE_NAME_OR_ID`

## Demonstration
```shell
    $ heroku pipelines:transfer me@example.com -p example
    === example

    app name              stage
    ────────────────────  ───────────
    ⬢ example-dev         development
    ⬢ example-staging     staging
    ⬢ example-prod        production

     ▸    This will transfer example and all of the listed apps to the me@example.com account
     ▸    to proceed, type edamame or re-run this command with --confirm example
    > example
    Transferring example pipeline to the me@example.com account... done

    $ heroku pipelines:transfer acme-widgets -p example
    === example

    app name              stage
    ────────────────────  ───────────
    ⬢ example-dev         development
    ⬢ example-staging     staging
    ⬢ example-prod        production

     ▸    This will transfer example and all of the listed apps to the acme-widgets team
     ▸    to proceed, type edamame or re-run this command with --confirm example
    > example

    Transferring example pipeline to the acme-widgets team... done
```
## Who's Affected
Pipelines users

## Blockers & upstream dependencies
- [ ] Deploy the new endpoint
