### PR TITLE
Remove JSON.stringify(options.body)

### DIFF
--- a/lib/kolkrabbi-api.js
+++ b/lib/kolkrabbi-api.js
@@ -8,9 +8,6 @@ module.exports = class KolkrabbiAPI {
   }
 
   request (url, options = {}) {
-    if (options.body) {
-      options.body = JSON.stringify(options.body)
-    }
 
     options.headers = Object.assign({
       Authorization: `Bearer ${this.token}`,

--- a/lib/kolkrabbi-api.js
+++ b/lib/kolkrabbi-api.js
@@ -8,7 +8,6 @@ module.exports = class KolkrabbiAPI {
   }
 
   request (url, options = {}) {
-
     options.headers = Object.assign({
       Authorization: `Bearer ${this.token}`,
       'User-Agent': this.version


### PR DESCRIPTION
Removed `JSON.stringify(options.body)` as it causes `is.plainObject(body)` to fail in `heroku-cli-util`.  This fixes #80.