### PR TITLE
Enableci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Added command `ci:enable` and `ci:disable` for existing pipelines.
+
 ## [2.5.4] 2018-04-18
 
 - Switch to http-call from got

--- a/commands/ci/disable.js
+++ b/commands/ci/disable.js
@@ -1,0 +1,32 @@
+const cli = require('heroku-cli-util')
+const co = require('co')
+const { flags } = require('@heroku-cli/command')
+const api = require('../../lib/api')
+const KolkrabbiAPI = require('../../lib/kolkrabbi-api')
+
+module.exports = {
+  topic: 'ci',
+  command: 'disable',
+  description: 'disable ci on an existing pipeline',
+  help: `Example:
+
+    $ heroku ci:disable -p mypipeline
+    Disabling CI ... done`,
+  needsApp: false,
+  needsAuth: true,
+  wantsOrg: false,
+  args: [],
+  flags: [
+    flags.pipeline({ name: 'pipeline', required: true, hasValue: true })
+  ],
+  run: cli.command(co.wrap(function* (context, heroku) {
+    const kolkrabbi = new KolkrabbiAPI(context.version, heroku.options.token)
+    const pipelines = yield api.getPipeline(heroku, context.flags.pipeline)
+    const settings = { ci: false }
+
+    yield cli.action(
+      'Disabling CI',
+      kolkrabbi.updatePipelineRepository(pipelines.id, settings)
+    )
+  }))
+}

--- a/commands/ci/enable.js
+++ b/commands/ci/enable.js
@@ -1,0 +1,32 @@
+const cli = require('heroku-cli-util')
+const co = require('co')
+const { flags } = require('@heroku-cli/command')
+const api = require('../../lib/api')
+const KolkrabbiAPI = require('../../lib/kolkrabbi-api')
+
+module.exports = {
+  topic: 'ci',
+  command: 'enable',
+  description: 'enable ci on an existing pipeline',
+  help: `Example:
+
+    $ heroku ci:enable -p mypipeline
+    Enabling CI ... done`,
+  needsApp: false,
+  needsAuth: true,
+  wantsOrg: false,
+  args: [],
+  flags: [
+    flags.pipeline({ name: 'pipeline', required: true, hasValue: true })
+  ],
+  run: cli.command(co.wrap(function* (context, heroku) {
+    const kolkrabbi = new KolkrabbiAPI(context.version, heroku.options.token)
+    const pipelines = yield api.getPipeline(heroku, context.flags.pipeline)
+    const settings = { ci: true }
+
+    yield cli.action(
+      'Enabling CI',
+      kolkrabbi.updatePipelineRepository(pipelines.id, settings)
+    )
+  }))
+}

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var flatten = require('lodash.flatten')
 
 exports.topic = [
   { name: 'pipelines', description: 'manage collections of apps in pipelines' },
-  { name: 'reviewapps', description: 'manage reviewapps in pipelines' }
+  { name: 'reviewapps', description: 'manage reviewapps in pipelines' },
+  { name: 'ci', description: 'run an application test suite on Heroku' }
 ]
 
 exports.commands = flatten([
@@ -20,5 +21,7 @@ exports.commands = flatten([
   require('./commands/pipelines/setup.js'),
   require('./commands/pipelines/transfer.js'),
   require('./commands/review_apps/disable.js'),
-  require('./commands/review_apps/enable.js')
+  require('./commands/review_apps/enable.js'),
+  require('./commands/ci/enable.js'),
+  require('./commands/ci/disable.js')
 ])

--- a/test/commands/ci/disable.js
+++ b/test/commands/ci/disable.js
@@ -1,0 +1,38 @@
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const expect = require('chai').expect
+const cmd = require('../../../commands/ci/disable')
+
+describe('ci:disable', function () {
+  let pipeline, kolkrabbi, api
+
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.disableNetConnect()
+
+    pipeline = {
+      id: '123-pipeline',
+      name: 'my-pipeline'
+    }
+
+    kolkrabbi = nock('https://kolkrabbi.heroku.com')
+    kolkrabbi.patch(`/pipelines/${pipeline.id}/repository`).reply(200, {})
+
+    api = nock('https://api.heroku.com')
+    api.get(`/pipelines/${pipeline.name}`).reply(200, pipeline)
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
+
+  it('it succeeds with defaults', function () {
+    return cmd.run({
+      flags: {
+        pipeline: pipeline.name
+      }
+    }).then(() => {
+      expect(cli.stderr).to.include('Disabling CI')
+    })
+  })
+})

--- a/test/commands/ci/enable.js
+++ b/test/commands/ci/enable.js
@@ -1,0 +1,38 @@
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const expect = require('chai').expect
+const cmd = require('../../../commands/ci/enable')
+
+describe('ci:enable', function () {
+  let pipeline, kolkrabbi, api
+
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.disableNetConnect()
+
+    pipeline = {
+      id: '123-pipeline',
+      name: 'my-pipeline'
+    }
+
+    kolkrabbi = nock('https://kolkrabbi.heroku.com')
+    kolkrabbi.patch(`/pipelines/${pipeline.id}/repository`).reply(200, {})
+
+    api = nock('https://api.heroku.com')
+    api.get(`/pipelines/${pipeline.name}`).reply(200, pipeline)
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
+
+  it('it succeeds with defaults', function () {
+    return cmd.run({
+      flags: {
+        pipeline: pipeline.name
+      }
+    }).then(() => {
+      expect(cli.stderr).to.include('Enabling CI')
+    })
+  })
+})


### PR DESCRIPTION
---
Thanks for your contribution to heroku-pipelines!
---

## Checklist

The checklist enumerates the tasks you set out to do before the PR becomes ready for review

- [x] Implement feature
- [x] Write tests
- [ ] Update yarn.lock
- [x] Update [CHANGELOG.md](https://github.com/heroku/heroku-pipelines/blob/master/CHANGELOG.md)
- [ ] Update Dev Center Docs
- [ ] Publish a new entry to [Heroku Changelog](https://devcenter.heroku.com/changelog)

## Why
There was no way to enable (or disable) CI on an existing pipeline through the Heroku CLI.

## What are the acceptance criteria for the change?
- [ ] [DevEx](https://github.com/heroku/devex) gives a :+1:

## How can the change be tested
- `DEBUG=nock.* mocha test/commands/ci/`
- `heroku ci:enable -p <yourpipeline>`
- `heroku ci:disable -p <yourpipeline>`

## Demonstration
- Help text:

![image](https://user-images.githubusercontent.com/746259/39026019-7a1b11e0-43ff-11e8-9152-18cab8bce140.png)

- Command GIF:

![herokuci](https://user-images.githubusercontent.com/746259/39026085-f98488f8-43ff-11e8-92e1-a88073f3cd5a.gif)

## Who's Affected
How many users will be affected by the change? Does it affect to 100% of our users, or just a subset of them?

None. It's a new command.

## Blockers & upstream dependencies

None.
