### PR TITLE
Fix exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Re-add the `disambiguatePipeline` export
+
 ## [2.5.7] 2018-04-21
 
 - Exclude tests files from tarball

--- a/index.js
+++ b/index.js
@@ -22,3 +22,5 @@ exports.commands = flatten([
   require('./commands/review_apps/disable.js'),
   require('./commands/review_apps/enable.js')
 ])
+
+exports.disambiguatePipeline = require('./lib/disambiguate')


### PR DESCRIPTION
## Checklist

- [x] Implement feature
- [ ] Write tests
- [x] Update [CHANGELOG.md](https://github.com/heroku/heroku-pipelines/blob/master/CHANGELOG.md)
- [ ] Update Dev Center Docs
- [ ] Publish a new entry to [Heroku Changelog](https://devcenter.heroku.com/changelog)

## Why

In 125249b1ca, the `disambiguatePipeline` export was removed but the heroku-ci plugin [relies](https://github.com/heroku/heroku-ci/blob/98d57407d/lib/utils.js#L3) on this export.

## How can the change be tested

Run `heroku ci:debug -p acme` in a repository where Heroku CI is enabled.