### PR TITLE
Typo in help text

### DIFF
--- a/commands/pipelines/transfer.js
+++ b/commands/pipelines/transfer.js
@@ -45,7 +45,7 @@ module.exports = {
     ⬢ example-prod        production
 
      ▸    This will transfer example and all of the listed apps to the me@example.com account
-     ▸    to proceed, type edamame or re-run this command with --confirm example
+     ▸    to proceed, type example or re-run this command with --confirm example
     > example
     Transferring example pipeline to the me@example.com account... done
 
@@ -59,7 +59,7 @@ module.exports = {
     ⬢ example-prod        production
 
      ▸    This will transfer example and all of the listed apps to the acme-widgets team
-     ▸    to proceed, type edamame or re-run this command with --confirm example
+     ▸    to proceed, type example or re-run this command with --confirm example
     > example
 
     Transferring example pipeline to the acme-widgets team... done`,


### PR DESCRIPTION
Replaced "Edamame" with "example"

---
Thanks for your contribution to heroku-pipelines!
---

## Checklist

The checklist enumerates the tasks you set out to do before the PR becomes ready for review

- [x] Implement feature
- [N/A] Write tests
- [N/A] Update yarn.lock
- [N/A] Update [CHANGELOG.md](https://github.com/heroku/heroku-pipelines/blob/master/CHANGELOG.md)
- [N/A] Update Dev Center Docs
- [N/A] Publish a new entry to [Heroku Changelog](https://devcenter.heroku.com/changelog)

## Why

The example given when checking the help menu on the command line is confusing as it mentions "edamame" as the name of the pipeline instead of "example".  

## What are the acceptance criteria for the change?
- [ ] [DevEx](https://github.com/heroku/devex) gives a :+1:
- [ ] @person provides a :+1: that this PR yields the desired results

## How can the change be tested
- enumerate a *list* of steps that the reviewer may step through to fully experience the changeset being introduced

From the command prompt, please run `heroku pipelines:transfer --help`.  You should no longer see the reference to "edamame".

## Demonstration
- If the changeset includes user-visible results, please include before and after screenshots

Before:
<img width="551" alt="before-change" src="https://user-images.githubusercontent.com/95606/40593974-29a7c0e2-6267-11e8-952c-d7a79cdf4ac5.png">

After:



## Who's Affected
How many users will be affected by the change? Does it affect to 100% of our users, or just a subset of them?

100%

## Blockers & upstream dependencies
- None